### PR TITLE
Update AWS Xray to Version 1.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require": {
 		"php": ">=7.1",
 		"humanmade/wp-redis-predis-client": "0.1.0",
-		"humanmade/aws-xray": "1.1.2",
+		"humanmade/aws-xray": "1.1.3",
 		"humanmade/s3-uploads": "2.1.0-RC2",
 		"humanmade/cavalcade": "1.0.0",
 		"humanmade/wp-redis": "0.7.1",


### PR DESCRIPTION
- Use shutdown hook instead of register_shutdown_runction #32