### PR TITLE
Ensure Cloud configuration is respected.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -137,6 +137,34 @@ function get_config() {
 }
 
 /**
+ * Load the object cache.
+ *
+ * Check the object caching configuration and load either memcached
+ * or redis as appropriate.
+ *
+ * @deprecated 1.1.0 Object caching setup moved to dedicated functions.
+ */
+function load_object_cache() {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		trigger_error(
+			sprintf(
+				__( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' ),
+				__FUNCTION__,
+				'1.1.0',
+				'load_object_cache_*()'
+			)
+		);
+	}
+	$config = get_config();
+
+	if ( $config['memcached'] ) {
+		load_object_cache_memcached();
+	} elseif ( $config['redis'] ) {
+		load_object_cache_redis();
+	}
+}
+
+/**
  * Load the Memcached Object Cache dropin.
  */
 function load_object_cache_memcached() {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,7 +29,7 @@ function bootstrap() {
 	}
 
 	add_filter( 'wp_mail_from', function ( string $email ) use ( $config ) : string {
-		return $config['email-from-address'];
+		return ! empty( $config['email-from-address'] ) ? $config['email-from-address'] : $email;
 	}, 1 );
 
 	// Load the platform as soon as WP is loaded.
@@ -133,8 +133,11 @@ function get_config() {
  * Load the Object Cache dropin.
  */
 function load_object_cache() {
-	wp_using_ext_object_cache( true );
 	$config = get_config();
+	if ( ! $config['memcached'] && ! $config['redis'] ) {
+		return;
+	}
+	wp_using_ext_object_cache( true );
 
 	if ( $config['memcached'] ) {
 		require ROOT_DIR . '/vendor/humanmade/wordpress-pecl-memcached-object-cache/object-cache.php';
@@ -187,6 +190,10 @@ function disable_no_cache_headers_on_admin_ajax_nopriv() {
  * Load the db dropin.
  */
 function load_db() {
+	$config = get_config();
+	if ( ! $config['ludicrousdb'] ) {
+		return;
+	}
 	require_once ABSPATH . WPINC . '/wp-db.php';
 	require_once dirname( __DIR__ ) . '/dropins/ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php';
 	require_once __DIR__ . '/class-db.php';

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -146,15 +146,15 @@ function get_config() {
  * Check the object caching configuration and load either memcached
  * or redis as appropriate.
  *
- * @deprecated 1.1.0 Object caching setup moved to dedicated functions.
+ * @deprecated 1.0.1 Object caching setup moved to dedicated functions.
  */
 function load_object_cache() {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		trigger_error(
 			sprintf(
-				__( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' ),
+				'%1$s is deprecated since version %2$s! Use %3$s instead.',
 				__FUNCTION__,
-				'1.1.0',
+				'1.0.1',
 				'load_object_cache_*()'
 			)
 		);

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,7 +29,11 @@ function bootstrap() {
 	}
 
 	add_filter( 'wp_mail_from', function ( string $email ) use ( $config ) : string {
-		return ! empty( $config['email-from-address'] ) ? $config['email-from-address'] : $email;
+		return filter_var(
+			$config['email-from-address'],
+			FILTER_VALIDATE_EMAIL,
+			FILTER_NULL_ON_FAILURE
+		) ?? $email;
 	}, 1 );
 
 	// Load the platform as soon as WP is loaded.


### PR DESCRIPTION
Adds checks to ensure the following configuration options are respected:

* `ludicrousdb`
* Either `redis` or `memcached` are enabled before loading object caching
* Logic check of `email-from-address` to ensure it's set and not falsey

Additionally I am unsure whether 

* `bootstrap()` should return early if `! $config['enabled']`
* `SES_To_CloudWatch\bootstrap();` and `CloudWatch_Logs\bootstrap();` should be conditional on `audit-log-to-cloudwatch || php-errors-to-cloudwatch`.