### PR TITLE
Don't use persistent MySQL connections

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -13,7 +13,7 @@ class DB extends LudicrousDB {
 	 *
 	 * @public bool
 	 */
-	public $persistent = true;
+	public $persistent = false;
 
 	/**
 	 * Track total time waiting for database responses;


### PR DESCRIPTION
In https://github.com/humanmade/terraform-app-stack/pull/206 we are not using tls for the mysql connection, so we don't need to use persistent connections.