### PR TITLE
Fix branding

### DIFF
--- a/docs/build-scripts.md
+++ b/docs/build-scripts.md
@@ -1,6 +1,6 @@
 # Build Scripts
 
-As part of the deployment process, HM Cloud supports running the running of tasks to handle pre-deployment tasks such as minifying JavaScript, running webpack, compiling SASS, etc. The specific build process is defined in a file `.build-script` in the root of your project's git repository.
+As part of the deployment process, Altis supports running the running of tasks to handle pre-deployment tasks such as minifying JavaScript, running webpack, compiling SASS, etc. The specific build process is defined in a file `.build-script` in the root of your project's git repository.
 
 At a minimum the build script should install the composer dependencies:
 

--- a/docs/geo-targeting.md
+++ b/docs/geo-targeting.md
@@ -1,6 +1,6 @@
 # Geo Targeting / GeoIP
 
-HM Cloud supports geolocation targeting when specifically enabled. Once enabled, developers can make use of the `Cloudfront-Viewer-Country` HTTP Header to serve content on a per-country basis.
+Altis supports geolocation targeting when specifically enabled. Once enabled, developers can make use of the `Cloudfront-Viewer-Country` HTTP Header to serve content on a per-country basis.
 
 To enable Geo Targeting contact the Altis team.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,17 +1,17 @@
 # Limitations
 
-There are several design decisions, typically for performance and security that impose some limitations on developers who may be used to certain practices. We've tried to document practical limitations of HM Cloud, with rationale to assist developers in writing more bug free, optimized code on HM Cloud.
+There are several design decisions, typically for performance and security that impose some limitations on developers who may be used to certain practices. We've tried to document practical limitations of Altis, with rationale to assist developers in writing more bug free, optimized code on Altis.
 
 
 ## Filesystem Not Writable
 
-The root filesystem outside of the uploads directory (returned by `wp_upload_dir()`) is not writable on HM Cloud. It's also possible to use `sys_get_temp_dir()` to write to the temporary filesystem when needed. This is to protect code-base integrity, and prevent malicious code being able to adjust the code base in the event of a security breach.
+The root filesystem outside of the uploads directory (returned by `wp_upload_dir()`) is not writable on Altis. It's also possible to use `sys_get_temp_dir()` to write to the temporary filesystem when needed. This is to protect code-base integrity, and prevent malicious code being able to adjust the code base in the event of a security breach.
 
 As such, plugin and WordPress Core updates can not be performed from within the WordPress Admin, and should always instead be made via the GitHub repository as a code change.
 
 ## Uploads Directory Stored Remotely
 
-On HM Cloud the uploads directory is a remote stream wrapper, this means you should not perform filesystem reads excessively. For example, no page render should cause a filesystem read. Store any details you need to render a page about a file in the database.
+On Altis the uploads directory is a remote stream wrapper, this means you should not perform filesystem reads excessively. For example, no page render should cause a filesystem read. Store any details you need to render a page about a file in the database.
 
 ## User Agent Not Available
 
@@ -25,11 +25,11 @@ Due to caching rules, the HTTP Referer header is not available in PHP. Any requi
 
 ## No PHP Sessions
 
-[PHP Sessions](http://php.net/manual/en/features.sessions.php) are not supported on HM Cloud. Where session data is needed developers should either store state on the client via cookies, or against the user's object in the WordPress database. All web requests on HM Cloud are stateless.
+[PHP Sessions](http://php.net/manual/en/features.sessions.php) are not supported on Altis. Where session data is needed developers should either store state on the client via cookies, or against the user's object in the WordPress database. All web requests on Altis are stateless.
 
 ## Web Requests to PHP Files
 
-Direct access to PHP files is not allowed on HM Cloud, outside of `/wp-admin/*`. For example, a request for `https://example.com/wp-content/plugins/my-plugin.php` will fail. All requests for PHP should be routed via WordPress' rewrite rules or similar.
+Direct access to PHP files is not allowed on Altis, outside of `/wp-admin/*`. For example, a request for `https://example.com/wp-content/plugins/my-plugin.php` will fail. All requests for PHP should be routed via WordPress' rewrite rules or similar.
 
 ## Execution Time Limit
 
@@ -41,4 +41,4 @@ We do not support requests for custom PHP modules. The PHP modules we have insta
 
 ## WP_Filesystem Not Supported
 
-The `WP_filesystem` WordPress API is not currently supported on HM Cloud, this is typically only used in plugin / WordPress Core updates which should instead be performed by GitHub Pull Requests.
+The `WP_filesystem` WordPress API is not currently supported on Altis, this is typically only used in plugin / WordPress Core updates which should instead be performed by GitHub Pull Requests.

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,6 +1,6 @@
 # Accessing Logs
 
-You have access to several types of logging from sites on HM Cloud have following logs available:
+You have access to several types of logging from sites on Altis have following logs available:
 
 - PHP Error log
 - Nginx Error log

--- a/docs/page-caching.md
+++ b/docs/page-caching.md
@@ -1,6 +1,6 @@
 # Page Caching
 
-The majority of the pages viewed on HM Cloud will be cached to improve performance and delivery time to the user. Its necessary to take into account the page cache when developing - considerations are listed at the bottom of this page. All pages are cached by default, and the following rules excluded specific cases:
+The majority of the pages viewed on Altis will be cached to improve performance and delivery time to the user. Its necessary to take into account the page cache when developing - considerations are listed at the bottom of this page. All pages are cached by default, and the following rules excluded specific cases:
 
 - All `POST` requests are not cached
 - Any requests with cookies matching the patterns `wordpress_*`, `wp-*`, `wp_*`, `comment_*` and `hm_*`are not cached.

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * On HM Cloud, all configuration of DB constants (etc) will be put
+ * On Altis, all configuration of DB constants (etc) will be put
  * in to a wp-config-production.php in the web root.
  */
 


### PR DESCRIPTION
This PR eliminates all appearances of the string `HM Cloud` (case-sensitive) in favour of `Altis`.

Didn’t touch any code; docs and 1 comment in wp-config.php only.