### PR TITLE
Change package type to library

### DIFF
--- a/dropins/batcache/composer.json
+++ b/dropins/batcache/composer.json
@@ -2,7 +2,7 @@
   "name"       : "humanmade/batcache",
   "description": "A memcached HTML page cache for WordPress.",
   "homepage"   : "https://github.com/humanmade/batcache",
-  "type"       : "wordpress-muplugin",
+  "type"       : "library",
   "license"    : "GPL-2.0+",
   "support"    : {
     "issues": "https://github.com/humanmade/batcache/issues",


### PR DESCRIPTION
Using this as a mu-plugin will put it into the wrong location for Altis.