### PR TITLE
Backport: Set the DB `dbname` etc properties

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -22,7 +22,6 @@ class DB extends LudicrousDB {
 	 */
 	public $time_spent = 0;
 
-
 	function query( $query ) {
 		$start = microtime( true );
 		$result = parent::query( $query );
@@ -60,5 +59,24 @@ class DB extends LudicrousDB {
 			}
 		}
 		return compact( 'charset', 'collate' );
+	}
+
+	/**
+	 * Add the connection parameters for a database.
+	 *
+	 * This overrides the parent method in LudicrousDB, as we want to
+	 * populte the dbname, dbuser etc instance vairables for compatibilty with
+	 * wpdb, and code that relies on those variables being set.
+	 *
+	 * @param array $db The database connection details.
+	 */
+	public function add_database( array $db = [] ) {
+		if ( ! empty( $db['write'] ) ) {
+			$this->dbname     = $db['name'];
+			$this->dbpassword = $db['password'];
+			$this->dbuser     = $db['user'];
+			$this->dbhost     = $db['host'];
+		}
+		parent::add_database( $db );
 	}
 }


### PR DESCRIPTION
LudicrousDB doesn't provide the `dbname`, `dbuser` etc instance vars on the `global $wpdb` object, which is needed by WP CLI (and some others) to detect what the DB name is. This is used when getting a list of tables for example, which breaks with LudicrousDB. Also, search-replace commands also break unless passed the `--all-tables` flag.

LudicrousDB doesn't set these almost for a good reason: each host you add to LudicrousDB _could_ use a different database name, so there is no "single" DB name, hence no setting of an instance variable for `dbname`. Instead, I decided to go for a better default: if a database host is configured that has `write` properties, then use that one as the host (etc) references in the instance variables.