### PR TITLE
Check for REQUEST_URI before using in healthchecks

### DIFF
--- a/inc/healthcheck/inc/cavalcade/namespace.php
+++ b/inc/healthcheck/inc/cavalcade/namespace.php
@@ -15,7 +15,7 @@ const HEALTHY_THRESHOLD = 900; // 15 mins
  */
 function bootstrap() {
 	add_action( JOB_HOOK, __NAMESPACE__ . '\\set_last_run' );
-	// @codingStandardsIgnoreLine
+	// phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
 	add_filter( 'cron_schedules', __NAMESPACE__ . '\\add_cron_schedule' );
 
 	// Schedule if not already scheduled.

--- a/inc/healthcheck/inc/cavalcade/namespace.php
+++ b/inc/healthcheck/inc/cavalcade/namespace.php
@@ -15,6 +15,7 @@ const HEALTHY_THRESHOLD = 900; // 15 mins
  */
 function bootstrap() {
 	add_action( JOB_HOOK, __NAMESPACE__ . '\\set_last_run' );
+	// @codingStandardsIgnoreLine
 	add_filter( 'cron_schedules', __NAMESPACE__ . '\\add_cron_schedule' );
 
 	// Schedule if not already scheduled.

--- a/inc/healthcheck/inc/namespace.php
+++ b/inc/healthcheck/inc/namespace.php
@@ -10,7 +10,7 @@ function bootstrap() {
 		require_once __DIR__ . '/class-cli-command.php';
 		WP_CLI::add_command( 'healthcheck', __NAMESPACE__ . '\\CLI_Command' );
 	}
-	if ( '/healthcheck/' !== $_SERVER['REQUEST_URI'] ) {
+	if ( ! isset( $_SERVER['REQUEST_URI'] ) || '/healthcheck/' !== $_SERVER['REQUEST_URI'] ) {
 		return;
 	}
 	output_page( run_checks() );
@@ -178,4 +178,3 @@ function run_cron_healthcheck() {
 
 	return true;
 }
-

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -44,7 +44,7 @@ function bootstrap() {
 	}
 
 	// We use install.php as the health check at the infrastructure level, so requests must
-	// succedd to /wp-admin/install.php. This is mostly because of legacy reasons. There's
+	// succeed to /wp-admin/install.php. This is mostly because of legacy reasons. There's
 	// an issue with loading /wp-admin/install.php on a domain that doesn't exist when
 	// SUBDOMAIN_INSTALL is defined as true. The requests to the health check are made with
 	// the server's IP address, so naturally it doesn't recognize the site as being installed.
@@ -57,7 +57,11 @@ function bootstrap() {
 	//
 	// To avoid warnings, client code should check if SUBDOMAIN_INSTALL is already defined before
 	// defining it.
-	if ( $_SERVER['REQUEST_URI'] === '/wp-admin/install.php' ) {
+	if (
+		$config['healthcheck'] &&
+		isset( $_SERVER['REQUEST_URI'] ) &&
+		$_SERVER['REQUEST_URI'] === '/wp-admin/install.php'
+	) {
 		define( 'SUBDOMAIN_INSTALL', false );
 	}
 }

--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -15,11 +15,10 @@ function bootstrap() {
  *
  */
 function increase_set_time_limit_on_async_upload() {
-	if (
-		isset( $_SERVER['REQUEST_URI'] ) &&
-		strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) !== false &&
-		ini_get( 'max_execution_time' ) < 120
-	) {
+	if ( ! isset( $_SERVER['REQUEST_URI'] ) || strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) === false ) {
+		return;
+	}
+	if ( ini_get( 'max_execution_time' ) < 120 ) {
 		set_time_limit( 120 );
 	}
 }

--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -21,7 +21,8 @@ function increase_set_time_limit_on_async_upload() {
 	if ( strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) === false ) {
 		return;
 	}
-	if ( ini_get( 'max_execution_time' ) >= 120 ) {
+	$time = ini_get( 'max_execution_time' );
+	if ( $time === 0 || $time >= 120 ) {
 		return;
 	}
 	set_time_limit( 120 );

--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -15,10 +15,14 @@ function bootstrap() {
  *
  */
 function increase_set_time_limit_on_async_upload() {
-	if ( ! isset( $_SERVER['REQUEST_URI'] ) || strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) === false ) {
+	if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
 		return;
 	}
-	if ( ini_get( 'max_execution_time' ) < 120 ) {
-		set_time_limit( 120 );
+	if ( strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) === false ) {
+		return;
 	}
+	if ( ini_get( 'max_execution_time' ) >= 120 ) {
+		return;
+	}
+	set_time_limit( 120 );
 }

--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -3,9 +3,7 @@
 namespace Altis\Cloud\Performance_Optimizations;
 
 function bootstrap() {
-	if ( strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) !== false ) {
-		increase_set_time_limit_on_async_upload();
-	}
+	increase_set_time_limit_on_async_upload();
 }
 
 /**
@@ -17,7 +15,11 @@ function bootstrap() {
  *
  */
 function increase_set_time_limit_on_async_upload() {
-	if ( ini_get( 'max_execution_time' ) < 120 ) {
+	if (
+		isset( $_SERVER['REQUEST_URI'] ) &&
+		strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) !== false &&
+		ini_get( 'max_execution_time' ) < 120
+	) {
 		set_time_limit( 120 );
 	}
 }


### PR DESCRIPTION
Checking for REQUEST_URI early in the cloud module breaks in contexts where `$_SERVER['REQUEST_URI']` is not set