### PR TITLE
Enable batcache redirect caching

### DIFF
--- a/inc/page_cache/namespace.php
+++ b/inc/page_cache/namespace.php
@@ -21,6 +21,9 @@ function bootstrap() {
 	$unique = array_unique( $unique );
 	$batcache['unique'] = $unique;
 
+	// Cache redirects
+	$batcache['cache_redirects'] = true;
+
 	// No-priv AJAX requests are public and should be cached.
 	add_action( 'admin_init', __NAMESPACE__ . '\\disable_no_cache_headers_on_admin_ajax_nopriv' );
 


### PR DESCRIPTION
Redirects are not currently being cached and have the potential for bringing down a site. Let's fix that!