### PR TITLE
Enable X-Ray always

### DIFF
--- a/load.php
+++ b/load.php
@@ -17,7 +17,7 @@ add_action( 'altis.modules.init', function () {
 		'memcached' => get_environment_architecture() === 'ec2',
 		'ludicrousdb' => true,
 		'healthcheck' => true,
-		'xray' => $is_cloud,
+		'xray' => true,
 		'email-from-address' => 'no-reply@humanmade.com',
 		'audit-log-to-cloudwatch' => $is_cloud,
 		'php-errors-to-cloudwatch' => $is_cloud,


### PR DESCRIPTION
This changes the default for X-Ray to be enabled in all environments, not such ecs and ec2. This is because X-Ray is now used in the Dev Tools too.

See https://github.com/humanmade/altis-dev-tools/issues/23