### PR TITLE
Set MULTISITE to prevent $wpdb from setting the database table prefix incorrectly

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -62,6 +62,7 @@ function bootstrap() {
 		isset( $_SERVER['REQUEST_URI'] ) &&
 		$_SERVER['REQUEST_URI'] === '/wp-admin/install.php'
 	) {
+		define( 'MULTISITE', false );
 		define( 'SUBDOMAIN_INSTALL', false );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/humanmade/altis-cloud/issues/77.

We discovered in some cases the fixes in https://github.com/humanmade/altis-cloud/pull/73 did not adequately prevent errors during healthchecks. Specifically, when `$wpdb` sets the blog prefix, it checks if `MULTISITE` is set and when not follows the standard `{prefix}_{blog id}_table` pattern. This PR sets `MULTISITE` in order to prevent this issue.

Of note is whether or not we should set it to `true` or `false`. We currently detect `WP_INSTALLING` and conditionally set `MULTISITE` if `WP_INSTALLING` is _not_ defined, which makes me think we need to set this to `false` to prevent any weirdness.