### PR TITLE
Add support for Query Monitor to DB drop-in

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -29,14 +29,14 @@ class DB extends LudicrousDB {
 	 *
 	 * @var array
 	 */
-	public $qm_php_vars = array(
+	public $qm_php_vars = [
 		'max_execution_time'  => null,
 		'memory_limit'        => null,
 		'upload_max_filesize' => null,
 		'post_max_size'       => null,
 		'display_errors'      => null,
 		'log_errors'          => null,
-	);
+	];
 
 	/**
 	 * Class constructor
@@ -82,9 +82,9 @@ class DB extends LudicrousDB {
 		}
 
 		$i = count( $this->queries ) - 1;
-		$this->queries[ $i ]['trace'] = new QM_Backtrace( array(
+		$this->queries[ $i ]['trace'] = new QM_Backtrace( [
 			'ignore_frames' => 1,
-		) );
+		] );
 
 		if ( ! isset( $this->queries[ $i ][3] ) ) {
 			$this->queries[ $i ][3] = $this->time_start;

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -4,6 +4,8 @@ namespace Altis\Cloud;
 
 use HM\Platform\XRay;
 use LudicrousDB;
+use QM_Backtrace;
+use WP_Error;
 
 class DB extends LudicrousDB {
 	public $check_tcp_responsiveness = false;
@@ -22,9 +24,50 @@ class DB extends LudicrousDB {
 	 */
 	public $time_spent = 0;
 
-	function query( $query ) {
+	/**
+	 * Query Monitor PHP variables
+	 *
+	 * @var array
+	 */
+	public $qm_php_vars = array(
+		'max_execution_time'  => null,
+		'memory_limit'        => null,
+		'upload_max_filesize' => null,
+		'post_max_size'       => null,
+		'display_errors'      => null,
+		'log_errors'          => null,
+	);
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct( $args = null ) {
+		foreach ( $this->qm_php_vars as $key => &$val ) {
+			$val = ini_get( $setting );
+		}
+
+		parent::__construct( $args );
+
+	}
+
+	/**
+	 * Perform a MySQL database query, using current database connection.
+	 *
+	 * @see wpdb::query()
+	 *
+	 * @param string $query Database query
+	 * @return int|false Number of rows affected/selected or false on error
+	 */
+	public function query( $query ) {
 		$start = microtime( true );
+		$has_qm = class_exists( '\\QM_Backtrace' );
+
+		if ( $has_qm && $this->show_errors ) {
+			$this->hide_errors();
+		}
+
 		$result = parent::query( $query );
+
 		$end = microtime( true );
 		if ( function_exists( 'HM\\Platform\\XRay\\trace_wpdb_query' ) ) {
 			$host = $this->current_host ?: $this->last_connection['host'];
@@ -33,6 +76,38 @@ class DB extends LudicrousDB {
 			XRay\trace_wpdb_query( $query, $start, $end, $result === false ? $this->last_error : null, $host );
 		}
 		$this->time_spent += $end - $start;
+
+		if ( ! $has_qm || ! SAVEQUERIES ) {
+			return $result;
+		}
+
+		$i = count( $this->queries ) - 1;
+		$this->queries[ $i ]['trace'] = new QM_Backtrace( array(
+			'ignore_frames' => 1,
+		) );
+
+		if ( ! isset( $this->queries[ $i ][3] ) ) {
+			$this->queries[ $i ][3] = $this->time_start;
+		}
+
+		if ( $this->last_error ) {
+			$code = 'qmdb';
+			if ( $this->use_mysqli ) {
+				if ( $this->dbh instanceof mysqli ) {
+					$code = mysqli_errno( $this->dbh );
+				}
+			} else {
+				if ( is_resource( $this->dbh ) ) {
+					// Please do not report this code as a PHP 7 incompatibility. Observe the surrounding logic.
+					// @codingStandardsIgnoreLine
+					$code = mysql_errno( $this->dbh );
+				}
+			}
+			$this->queries[ $i ]['result'] = new WP_Error( $code, $this->last_error );
+		} else {
+			$this->queries[ $i ]['result'] = $result;
+		}
+
 		return $result;
 	}
 

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -94,6 +94,7 @@ class DB extends LudicrousDB {
 			$code = 'qmdb';
 			if ( $this->use_mysqli ) {
 				if ( $this->dbh instanceof mysqli ) {
+					// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_errno
 					$code = mysqli_errno( $this->dbh );
 				}
 			} else {


### PR DESCRIPTION
Adds support into our custom DB drop-in for Query Monitor, which provide richer information about database queries, including a full trace and row information. It also allows breaking down queries by component, and rich error data.

Fixes #84.

Before | After
-- | --
<img width="1440" alt="Screen Shot 2019-11-18 at 17 35 40" src="https://user-images.githubusercontent.com/21655/69075743-e202e980-0a29-11ea-9036-db5c00aefb67.png"> | <img width="1440" alt="Screen Shot 2019-11-18 at 17 35 20" src="https://user-images.githubusercontent.com/21655/69075745-e3ccad00-0a29-11ea-9332-92b1c01f96ac.png">

Error Before | Error After
-- | --
<img width="1440" alt="Screen Shot 2019-11-18 at 17 40 01" src="https://user-images.githubusercontent.com/21655/69076028-7ff6b400-0a2a-11ea-8553-56ba326fe245.png"> | <img width="1440" alt="Screen Shot 2019-11-18 at 17 40 09" src="https://user-images.githubusercontent.com/21655/69076033-81c07780-0a2a-11ea-969e-67cc60c8e470.png">

cc @johnbillion - it'd be neat if the data collection part could be abstracted in QM so this is less brittle if you ever need to change the DB drop-in code.