### PR TITLE
Fix coding standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
 	],
 	"autoload": {
 		"files": [
+			"inc/healthcheck/namespace.php",
+			"inc/healthcheck/cavalcade/namespace.php",
 			"inc/namespace.php",
 			"wp-config.php"
 		]

--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -43,7 +43,7 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 			[
 				[
 					'timestamp' => time() * 1000,
-					// @codingStandardsIgnoreLine
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 					'message' => json_encode( $data ),
 				],
 			],
@@ -150,6 +150,7 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 				break;
 			}
 			$object = json_decode( $result[0]['value'] );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 			$object->meta = json_decode( json_encode( $object->meta ), true );
 			$items[] = $object;
 		}

--- a/inc/cavalcade_runner_to_cloudwatch/namespace.php
+++ b/inc/cavalcade_runner_to_cloudwatch/namespace.php
@@ -98,6 +98,7 @@ function on_end_job( Worker $worker, Job $job, string $status ) {
 	send_event_to_stream(
 		[
 			'timestamp' => time() * 1000,
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 			'message'   => json_encode( [
 				'hook'     => $job->hook,
 				'id'       => $job->id,

--- a/inc/healthcheck/cavalcade/namespace.php
+++ b/inc/healthcheck/cavalcade/namespace.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Altis\Healthcheck\Cavalcade;
+namespace Altis\Cloud\Healthcheck\Cavalcade;
 
 use WP_Error;
 

--- a/inc/healthcheck/class-cli-command.php
+++ b/inc/healthcheck/class-cli-command.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Altis\Healthcheck;
+namespace Altis\Cloud\Healthcheck;
 
 use cli;
 use WP_CLI;

--- a/inc/healthcheck/inc/namespace.php
+++ b/inc/healthcheck/inc/namespace.php
@@ -40,6 +40,7 @@ function output_page( array $checks ) {
 	}
 
 	if ( $format === 'json' ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 		echo json_encode( $checks );
 		exit;
 	}

--- a/inc/healthcheck/namespace.php
+++ b/inc/healthcheck/namespace.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Altis\Healthcheck;
+namespace Altis\Cloud\Healthcheck;
 
 use WP_CLI;
 use WP_Error;

--- a/inc/healthcheck/plugin.php
+++ b/inc/healthcheck/plugin.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Altis\Healthcheck;
-
-require_once __DIR__ . '/inc/namespace.php';
-require_once __DIR__ . '/inc/cavalcade/namespace.php';
-
-add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap' );
-add_action( 'plugins_loaded', __NAMESPACE__ . '\\Cavalcade\\bootstrap' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -330,10 +330,18 @@ function load_plugins() {
 	}
 
 	if ( $config['healthcheck'] ) {
-		Healthcheck\bootstrap();
-		Healthcheck\Cavalcade\bootstrap();
+		add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_healthcheck' );
 	}
+}
 
+/**
+ * Load and run healthcheck.
+ *
+ * Runs the Cloud healthcheck at /healthcheck/
+ */
+function load_healthcheck() {
+	Healthcheck\bootstrap();
+	Healthcheck\Cavalcade\bootstrap();
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -330,7 +330,8 @@ function load_plugins() {
 	}
 
 	if ( $config['healthcheck'] ) {
-		require dirname( __DIR__ ) . '/inc/healthcheck/plugin.php';
+		Healthcheck\bootstrap();
+		Healthcheck\Cavalcade\bootstrap();
 	}
 
 }

--- a/inc/ses_to_cloudwatch/namespace.php
+++ b/inc/ses_to_cloudwatch/namespace.php
@@ -24,6 +24,7 @@ function on_sent_message( $result, $message ) {
 		[
 			[
 				'timestamp' => time() * 1000,
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 				'message'   => json_encode( $message ),
 			],
 		],
@@ -43,6 +44,7 @@ function on_error_sending_message( Exception $e, $message ) {
 		[
 			[
 				'timestamp' => time() * 1000,
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 				'message'   => json_encode( [
 					'error'     => [
 						'class'   => get_class( $e ),


### PR DESCRIPTION
Let's fix up these dumb errors.

Main BC change is that `Altis\Healthcheck` is now `Altis\Cloud\Healthcheck`. Our modules interact with it via a filter, not directly, so shouldn't have an impact.