### PR TITLE
Update Cavalcade to 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"humanmade/wp-redis-predis-client": "0.1.0",
 		"humanmade/aws-xray": "1.2.2",
 		"humanmade/s3-uploads": "~2.1",
-		"humanmade/cavalcade": "1.0.0",
+		"humanmade/cavalcade": "1.0.1",
 		"humanmade/wp-redis": "0.7.1",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.0.0",
 		"humanmade/batcache": "1.3.0",


### PR DESCRIPTION
Addresses the issue of cavalcade tables being created with server default charset and collation rather than utf8mb4