### PR TITLE
Update batcache to 1.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"humanmade/cavalcade": "1.0.1",
 		"humanmade/wp-redis": "0.7.1",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.0.0",
-		"humanmade/batcache": "1.3.1",
+		"humanmade/batcache": "1.3.2",
 		"stuttter/ludicrousdb": "4.2.0",
 		"humanmade/aws-ses-wp-mail": "1.1.0"
 	},


### PR DESCRIPTION
Changelog:

- Fix max_age being set to 1 on Batcache HIT humanmade/batcache#13

--

This will need manually backporting to v2-branch too.