### PR TITLE
Fix warning through for `disable_no_cache_headers_on_admin_ajax_nopriv()`

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -252,18 +252,6 @@ function load_advanced_cache( $should_load ) {
 }
 
 /**
- * Remove the "no cache" headers that are sent on logged out admin-ajax.php requests.
- *
- * These requests can be cached, as they don't include private data.
- */
-function disable_no_cache_headers_on_admin_ajax_nopriv() {
-	if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX || is_user_logged_in() ) {
-		return;
-	}
-	array_map( 'header_remove', array_keys( wp_get_nocache_headers() ) );
-}
-
-/**
  * Load the ludicrousdb dropin.
  */
 function load_db() {

--- a/inc/page_cache/namespace.php
+++ b/inc/page_cache/namespace.php
@@ -85,3 +85,15 @@ function get_unique_cookies() : array {
 
 	return $unique_keys;
 }
+
+/**
+ * Remove the "no cache" headers that are sent on logged out admin-ajax.php requests.
+ *
+ * These requests can be cached, as they don't include private data.
+ */
+function disable_no_cache_headers_on_admin_ajax_nopriv() {
+	if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX || is_user_logged_in() ) {
+		return;
+	}
+	array_map( 'header_remove', array_keys( wp_get_nocache_headers() ) );
+}


### PR DESCRIPTION
Fixes #114 

I'm guessing the function should live in the `Altis\Cloud\Page_Cache` namespace.