### PR TITLE
Env indicator: Use altis blue instead of aqua

### DIFF
--- a/assets/environment-indicator.css
+++ b/assets/environment-indicator.css
@@ -7,7 +7,7 @@
 }
 
 #wpadminbar .altis-env-indicator {
-	background-color: #06A9CE;
+	background-color: #4667DE;
 	display: inline-block;
 	height: 1.2em;
 	margin-top: 6px;

--- a/inc/environment_indicator/namespace.php
+++ b/inc/environment_indicator/namespace.php
@@ -92,5 +92,5 @@ function add_admin_bar_dashboard_link( WP_Admin_Bar $wp_admin_bar ) {
  * Enqueue the environment indicator styles.
  */
 function enqueue_admin_scripts() {
-	wp_enqueue_style( 'altis-env-indicator', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/environment-indicator.css', [], '2020-02-03-1' );
+	wp_enqueue_style( 'altis-env-indicator', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/environment-indicator.css', [], '2020-02-05-2' );
 }


### PR DESCRIPTION
Meets WCAG AA standards.