### PR TITLE
Check Altis\ROOT_DIR is defined

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -8,7 +8,7 @@
 use const Altis\ROOT_DIR;
 
 // Don't self-initialize if this is not an Altis execution.
-if ( ! function_exists( 'add_action' ) ) {
+if ( ! function_exists( 'add_action' ) || ! defined( 'Altis\\ROOT_DIR' ) ) {
 	return;
 }
 


### PR DESCRIPTION
This will avoid an issue when trying to prepend `wordpress/wp-includes/plugin.php` early before any scripts in `vendor/bin/` are called. This allows us to document a supported method for running `phpunit` for instance against Altis <= v2.