### PR TITLE
Reduce polling on CloudWatch in Audit Log results

### DIFF
--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -142,6 +142,10 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 
 		$results = [ 'status' => 'Running' ];
 		while ( ! in_array( $results['status'], [ 'Failed', 'Cancelled', 'Complete' ], true ) ) {
+			// Limit how fast we poll CloudWatch via calls to getQueryResults.
+			// Queries take at a minimum 1 second, so we `sleep` before even
+			// making the first call.
+			sleep( 1 );
 			$results = cloudwatch_logs_client()->getQueryResults([
 				'queryId' => $query['queryId'],
 			] );


### PR DESCRIPTION
Follow up to https://github.com/humanmade/altis-cloud/pull/97.

This limits the request rate to CloudWatch when checking if queries are complete.