### PR TITLE
Error on install after updates to cavalcade 2.0.0

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -301,11 +301,6 @@ function load_plugins() {
 			define( 'DISABLE_WP_CRON', true );
 		}
 		require_once ROOT_DIR . '/vendor/humanmade/cavalcade/plugin.php';
-		// Wait until tables have been created to bootstrap cavalcade during install.
-		if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
-			remove_action( 'plugins_loaded', 'HM\\Cavalcade\\Plugin\\bootstrap' );
-			add_action( 'populate_options', 'HM\\Cavalcade\\Plugin\\bootstrap' );
-		}
 	}
 
 	// Define TACHYON_URL, as in the Cloud environment is "always on"


### PR DESCRIPTION
During installation the workaround we had previsously actually stopped the Cavalcade tables being created at all after the improved handling of that in 2.0.0 was added.