### PR TITLE
Revert "Update AWS X-Ray to 1.2.5"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"php": ">=7.1",
 		"humanmade/wp-redis-predis-client": "0.1.0",
-		"humanmade/aws-xray": "~1.2.7",
+		"humanmade/aws-xray": "1.2.7",
 		"humanmade/s3-uploads": "~2.1",
 		"humanmade/cavalcade": "^2.0.0",
 		"humanmade/wp-redis": "0.7.1",


### PR DESCRIPTION
Reverts humanmade/altis-cloud#150

I screwed up by adding a merge commit - going to do a fresh easily backportable commit to update it to `~1.2.7`