### PR TITLE
Fix page cache to allow dynamic unique param

### DIFF
--- a/inc/page_cache/namespace.php
+++ b/inc/page_cache/namespace.php
@@ -7,7 +7,10 @@ use function Altis\Cloud\get_config;
 
 function bootstrap() {
 	global $batcache;
-	$batcache = $batcache ?? [ 'ignored_query_string_params' => [], 'unique' => [] ];
+	$batcache = $batcache ?? [
+		'ignored_query_string_params' => [],
+		'unique' => []
+	];
 
 	$ignore_query_params = array_merge(
 		$batcache['ignored_query_string_params'] ?? [],

--- a/inc/page_cache/namespace.php
+++ b/inc/page_cache/namespace.php
@@ -9,7 +9,7 @@ function bootstrap() {
 	global $batcache;
 	$batcache = $batcache ?? [
 		'ignored_query_string_params' => [],
-		'unique' => []
+		'unique' => [],
 	];
 
 	$ignore_query_params = array_merge(

--- a/inc/page_cache/namespace.php
+++ b/inc/page_cache/namespace.php
@@ -7,13 +7,21 @@ use function Altis\Cloud\get_config;
 
 function bootstrap() {
 	global $batcache;
-	$batcache = $batcache ?? [];
+	$batcache = $batcache ?? [ 'ignored_query_string_params' => [], 'unique' => [] ];
+
+	$ignore_query_params = array_merge(
+		$batcache['ignored_query_string_params'] ?? [],
+		get_ignore_query_params()
+	);
+
+	$ignore_query_params = array_unique( $ignore_query_params );
 
 	// Ignore common query params.
-	$batcache['ignored_query_string_params'] = get_ignore_query_params();
+	$batcache['ignored_query_string_params'] = $ignore_query_params;
 
 	// Add unique key / values that should vary the page cache.
 	$unique = array_merge(
+		$batcache['unique'] ?? [],
 		get_unique_headers(),
 		get_unique_cookies()
 	);


### PR DESCRIPTION
This will allow developer to add `unique` based on query string or any dynamic conditions.

We can also add filter for the same.

