### PR TITLE
Add wp-db bail override

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -137,7 +137,7 @@ class DB extends LudicrousDB {
 	 * This function can not use any WordPress functions that read from the database, as that
 	 * will risk a recursion call.
 	 *
-	 * @param string $message    The Error message
+	 * @param string $message The Error message
 	 * @param string $error_code Optional. A Computer readable string to identify the error.
 	 */
 	public function bail( $message, $error_code = '500' ) {

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -129,4 +129,28 @@ class DB extends LudicrousDB {
 		}
 		parent::add_database( $db );
 	}
+
+	/**
+	 * Override the wpdb bail handler.
+	 *
+	 * We always want to bail and exit the script execution, not rely on $this->show_errors.
+	 * This function can not use any WordPress functions that read from the database, as that
+	 * will risk a recursion call.
+	 *
+	 * @param string $message    The Error message
+	 * @param string $error_code Optional. A Computer readable string to identify the error.
+	 */
+	public function bail( $message, $error_code = '500' ) {
+		header( 'Content-Type: text/html; charset=utf-8' );
+		status_header( 500 );
+		nocache_headers();
+		?>
+		<h1>Database Connection Error</h1>
+		<p><pre><?php echo $message //@codingStandardsIgnoreLine No escaping functions available here. ?></pre></p>
+		<?php if ( $error_code ) : ?>
+			<p>Code: <pre><?php echo $error_code //@codingStandardsIgnoreLine No escaping functions available here. ?></pre></p>
+		<?php endif ?>
+		<?php
+		exit;
+	}
 }


### PR DESCRIPTION
Currently `wpdb::bail` will not `exit` if `wpdb->show_errors` is set to `false`. This can be the case in several situations, such as Query Monitor being enabled. Also, the default `wpdb::bail` implementation use `wp_die` which reads form the database, causing a circular call loop in some cases.

We don't need to ever no-exit on a database bail call.