### PR TITLE
[Backport v3-branch] Move ES request signing to Cloud Module

### DIFF
--- a/inc/healthcheck/namespace.php
+++ b/inc/healthcheck/namespace.php
@@ -2,6 +2,7 @@
 
 namespace Altis\Cloud\Healthcheck;
 
+use Altis\Cloud;
 use WP_CLI;
 use WP_Error;
 
@@ -72,10 +73,11 @@ function output_page( array $checks ) {
  */
 function run_checks() : array {
 	$checks = [
-		'mysql'        => run_mysql_healthcheck(),
+		'mysql' => run_mysql_healthcheck(),
 		'object-cache' => run_object_cache_healthcheck(),
 		'cron-waiting' => run_cron_healthcheck(),
-		'cron-canary'  => Cavalcade\check_health(),
+		'cron-canary' => Cavalcade\check_health(),
+		'elasticsearch' => run_elasticsearch_healthcheck(),
 	];
 
 	$checks = apply_filters( 'altis_healthchecks', $checks );
@@ -175,6 +177,30 @@ function run_cron_healthcheck() {
 
 	if ( $passed_due ) {
 		return new WP_Error( 'cron-passed-due', sprintf( '%d jobs passed their run date.', $passed_due ) );
+	}
+
+	return true;
+}
+
+/**
+ * Run ElasticSearch health check.
+ */
+function run_elasticsearch_healthcheck() {
+	$host = Cloud\get_elasticsearch_url();
+
+	// If no host is set then ElasticSearch not in use.
+	if ( empty( $host ) ) {
+		return true;
+	}
+
+	$response = wp_remote_get( $host . '/_cluster/health' );
+	if ( is_wp_error( $response ) ) {
+		return new WP_Error( 'elasticsearch-unhealthy', $response->get_error_message() );
+	}
+
+	$body = wp_remote_retrieve_body( $response );
+	if ( is_wp_error( $body ) ) {
+		return new WP_Error( 'elasticsearch-unhealthy', $body->get_error_message() );
 	}
 
 	return true;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,9 +76,6 @@ function bootstrap() {
 		define( 'SUBDOMAIN_INSTALL', false );
 	}
 
-	// Display environment details in admin sidebar.
-	Environment_Indicator\bootstrap();
-
 	// Sign ElasticSearch HTTP requests and log errors.
 	add_action( 'http_api_debug', __NAMESPACE__ . '\\log_elasticsearch_request_errors', 10, 5 );
 	add_filter( 'http_request_args', __NAMESPACE__ . '\\on_http_request_args', 11, 2 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -4,14 +4,14 @@ namespace Altis\Cloud;
 
 use Altis;
 use Aws\CloudFront\CloudFrontClient;
-use const Altis\ROOT_DIR;
-use function Altis\get_aws_sdk;
-use function Altis\get_config as get_platform_config;
-use function Altis\get_environment_architecture;
 use Aws\Credentials;
 use Aws\Credentials\CredentialProvider;
 use Aws\Signature\SignatureV4;
+use const Altis\ROOT_DIR;
 use Exception;
+use function Altis\get_aws_sdk;
+use function Altis\get_config as get_platform_config;
+use function Altis\get_environment_architecture;
 use GuzzleHttp\Psr7\Request;
 use HM\Platform\XRay;
 use Psr\Http\Message\RequestInterface;


### PR DESCRIPTION
Backporting #188


-------------

Move ES request signing to Cloud Module

ElasticSearch is no longer solely used for search, rather it is a core service of the infrastructure and therefore the cloud module.

This PR replicates the request signing, error logging and healthcheck from the search module in a back compatible way.

Currently if the search module is not enabled then ES requests for analytics data for example will fail. This is definitely a bug that needs to be addressed.

Fixes #187