### PR TITLE
Short-circuit Audit Log requests when they have enough data.

### DIFF
--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -148,7 +148,9 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 		}
 
 		$results = [ 'status' => 'Running' ];
+		$start_searching_time = time();
 		while ( ! in_array( $results['status'], [ 'Failed', 'Cancelled', 'Complete' ], true ) ) {
+
 			// Limit how fast we poll CloudWatch via calls to getQueryResults.
 			// Queries take at a minimum 1 second, so we `sleep` before even
 			// making the first call.
@@ -156,6 +158,22 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 			$results = CloudWatch_Logs\cloudwatch_logs_client()->getQueryResults([
 				'queryId' => $query['queryId'],
 			] );
+
+			$time_taken = time() - $start_searching_time;
+			// If we are looking for most recent results, we can short-circuit once we have enough
+			// in the results array, even if the query has not completed searching all records.
+			// We only trigger this behaviour at a minimum of 15 seconds, which gives the query time to
+			// complete as usual, which will mean that the total found results is correctly set.
+			// Short-circuiting the query early means the total counts will not be accurate, so we fix to 10k.
+			if ( $order === 'desc' && $results['status'] === 'Running' && count( $results['results'] ) === $limit && $time_taken > 15 ) {
+				$results['statistics']['recordsMatched'] = 10000;
+
+				// Stop the running query, as we won't be reading from it again.
+				CloudWatch_Logs\cloudwatch_logs_client()->stopQuery( [
+					'queryId' => $query['queryId'],
+				] );
+				break;
+			}
 		}
 
 		/**


### PR DESCRIPTION
Turns out that in-progress query responses have initial results already in the response, which I didn't realize. In cases when we are searching most-recent, we can assume once the results hits the limit, the results set will not change.

To keep total found rows accurate, I have put a 15 second limit when using this performance optimization. Though we might get the most recent 20 results in 2 seconds, we let it take u pto 15 seconds to fully complete, so we can get accurate totals counts.