### PR TITLE
Enforce purge limitation

### DIFF
--- a/docs/cdn-purge.md
+++ b/docs/cdn-purge.md
@@ -12,6 +12,8 @@ purge_cdn_paths( [
 
 Note that purging paths should be kept to only essential items as purging more than 1000 paths per month will incur overage charges.
 
+**Important note:** Due to AWS limitations, you **cannot** purge large numbers of paths at once. Do not call this function in bulk; contact the Altis Cloud team if you need to perform large numbers of invalidations.
+
 ## Automatic media purge rule
 
 By default, Altis will not remove uploaded media from the CDN cache when deleting attachments. You can enable this behavior from the project's configuration in `composer.json`. The example below shows the default configuration:

--- a/docs/cdn-purge.md
+++ b/docs/cdn-purge.md
@@ -12,7 +12,7 @@ purge_cdn_paths( [
 
 Note that purging paths should be kept to only essential items as purging more than 1000 paths per month will incur overage charges.
 
-**Important note:** Due to AWS limitations, you **cannot** purge large numbers of paths at once. Do not call this function in bulk; contact the Altis Cloud team if you need to perform large numbers of invalidations.
+**Important note:** Due to AWS limitations, you **cannot** purge large numbers of paths at once. Do not call this function in bulk; contact the Altis Cloud team if you need to perform large numbers of invalidations. The `purge_cdn_paths()` function is limited to 10 wildcards or 2000 static paths.
 
 ## Automatic media purge rule
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -20,11 +20,22 @@ use HM\Platform\XRay;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * CloudFront invalidation limit.
+ * CloudFront static paths invalidation limit.
+ *
+ * We can only invalidate 3000 total at once, so 2000 gives us some wiggle room.
  *
  * @see purge_cdn_paths()
  */
-const INVALIDATION_LIMIT = 10;
+const PATHS_INVALIDATION_LIMIT = 2000;
+
+/**
+ * CloudFront wildcard invalidation limit.
+ *
+ * We can only invalidate 15 total at once, so 10 gives us some wiggle room.
+ *
+ * @see purge_cdn_paths()
+ */
+const WILDCARD_INVALIDATION_LIMIT = 10;
 
 /**
  * Set up the Cloud Module.
@@ -743,8 +754,9 @@ function get_cloudfront_client() : CloudFrontClient {
 /**
  * Create purge request to invalidate CDN cache.
  *
- * There is a hard limit of 10 invalidations per HTTP request, due to
- * underlying limitations in AWS.
+ * This is limited to 10 wildcard invalidations and 2000 static path
+ * invalidations due to underlying limits in the CloudFront API. Consult the
+ * Altis Cloud team if you need to invalidate en masse.
  *
  * @see https://www.altis-dxp.com/resources/docs/cloud/cdn-purge/
  *
@@ -760,13 +772,21 @@ function get_cloudfront_client() : CloudFrontClient {
  * @return bool Returns true if invalidation successfully created, false on failure.
  */
 function purge_cdn_paths( array $paths_patterns ) : bool {
-	static $invalidated = 0;
-	$invalidated += count( $paths_patterns );
-	if ( $invalidated > INVALIDATION_LIMIT ) {
+	static $invalidated_static = 0;
+	static $invalidated_wild = 0;
+	foreach ( $paths_patterns as $pattern ) {
+		if ( strpos( $pattern, '*' ) !== null ) {
+			$invalidated_wild++;
+		} else {
+			$invalidated_static++;
+		}
+	}
+	if ( $invalidated_static > PATHS_INVALIDATION_LIMIT || $invalidated_wild > WILDCARD_INVALIDATION_LIMIT ) {
 		trigger_error(
 			sprintf(
-				'Cannot invalidate more than %d items per request, contact Altis support',
-				INVALIDATION_LIMIT
+				'Cannot invalidate more than %d wildcards or %d items per request, contact Altis support',
+				WILDCARD_INVALIDATION_LIMIT,
+				PATHS_INVALIDATION_LIMIT
 			),
 			E_USER_WARNING
 		);

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -775,7 +775,7 @@ function purge_cdn_paths( array $paths_patterns ) : bool {
 	static $invalidated_static = 0;
 	static $invalidated_wild = 0;
 	foreach ( $paths_patterns as $pattern ) {
-		if ( strpos( $pattern, '*' ) !== null ) {
+		if ( strpos( $pattern, '*' ) !== false ) {
 			$invalidated_wild++;
 		} else {
 			$invalidated_static++;


### PR DESCRIPTION
Replaces #196. See #186.

This goes further and enforces a maximum of 10 items per HTTP request. This is designed to be lower than the wildcard limit (15) in CloudFront, and is mainly designed to detect use of the function in loops, which is dangerous.