### PR TITLE
Disable persistent connections to prevent idle resources from being consumed

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -30,7 +30,7 @@ class DB extends LudicrousDB {
 	 *
 	 * @var bool
 	 */
-	public $persistent = true;
+	public $persistent = false;
 
 	/**
 	 * Track total time waiting for database responses;

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -30,7 +30,7 @@ class DB extends LudicrousDB {
 	 *
 	 * @var bool
 	 */
-	public $persistent = false;
+	public $persistent = ALTIS_PERSISTENT_DB_CONNS;
 
 	/**
 	 * Track total time waiting for database responses;

--- a/load.php
+++ b/load.php
@@ -9,6 +9,8 @@ namespace Altis\Cloud; // phpcs:ignore
 
 use Altis;
 
+defined( 'ALTIS_PERSISTENT_DB_CONNS' ) or define( 'ALTIS_PERSISTENT_DB_CONNS', true );
+
 add_action( 'altis.modules.init', function () {
 	$is_cloud = in_array( Altis\get_environment_architecture(), [ 'ec2', 'ecs' ], true );
 	$default_settings = [


### PR DESCRIPTION
We've observed some environments have a high level of connections that are sitting idle, which wastes resources and triggers false alarms. I'd like to experiment with disabling persistent connections to see what difference that makes.