### PR TITLE
Fix cloudwatch_logs_client reference

### DIFF
--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -162,7 +162,7 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 				$results['statistics']['recordsMatched'] = 10000;
 
 				// Stop the running query, as we won't be reading from it again.
-				CloudWatch_Logs\cloudwatch_logs_client()->stopQuery( [
+				cloudwatch_logs_client()->stopQuery( [
 					'queryId' => $query['queryId'],
 				] );
 				break;


### PR DESCRIPTION
There was an error in the backport of https://github.com/humanmade/altis-cloud/pull/194 which causes a fatal when tryign to view the audit log. This broke Altis/cloud 3.0.9 and 3.0.10.