### PR TITLE
Backport v3: Catch exceptions from StopQuery in CloudWatch

### DIFF
--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -161,10 +161,14 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 			if ( $order === 'desc' && $results['status'] === 'Running' && count( $results['results'] ) === $limit && $time_taken > 15 ) {
 				$results['statistics']['recordsMatched'] = 10000;
 
-				// Stop the running query, as we won't be reading from it again.
-				cloudwatch_logs_client()->stopQuery( [
-					'queryId' => $query['queryId'],
-				] );
+				try {
+					// Stop the running query, as we won't be reading from it again.
+					cloudwatch_logs_client()->stopQuery( [
+						'queryId' => $query['queryId'],
+					] );
+				} catch ( Exception $e ) {
+					trigger_error( sprintf( 'Error stopping CloudWatch Logs query: %s', $e->getMessage() ), E_USER_WARNING );
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
In cases where StopQuery fails, we don't want the exception to bubble, as it is non-essential.

See #202