### PR TITLE
Check architecture when adding ec2 metadata

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -52,7 +52,9 @@ function bootstrap() {
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/inc/namespace.php';
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/plugin.php';
 		add_filter( 'aws_xray.redact_metadata', __NAMESPACE__ . '\\remove_xray_metadata' );
-		add_filter( 'aws_xray.trace_to_daemon', __NAMESPACE__ . '\\add_ec2_instance_data_to_xray' );
+		if ( in_array( Altis\get_environment_architecture(), [ 'ec2', 'ecs' ], true ) ) {
+			add_filter( 'aws_xray.trace_to_daemon', __NAMESPACE__ . '\\add_ec2_instance_data_to_xray' );
+		}
 		XRay\bootstrap();
 	}
 


### PR DESCRIPTION
Fetching EC2 instance metadata spits out an error on local environments. This was never spotted until #210 got merged and fixed the status check.