### PR TITLE
Don't load XRay on all CLI invocations

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -47,7 +47,7 @@ function bootstrap() {
 	if (
 		$config['xray']
 		&& function_exists( 'xhprof_sample_enable' )
-		&& ( ! defined( 'WP_CLI' ) || ! WP_CLI )
+		&& php_sapi_name() !== 'cli'
 		&& ! class_exists( 'HM\\Cavalcade\\Runner\\Runner' )
 	) {
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/inc/namespace.php';


### PR DESCRIPTION
PHP can be run via the command line directly and not just WP CLI - we need to account for that case too as currently when running unit tests the install step will cause XRay to spit out some unnecessary warnings.