### PR TITLE
Fix InvalidSequenceToken in CloudWatch Logs

### DIFF
--- a/inc/cloudwatch_logs/namespace.php
+++ b/inc/cloudwatch_logs/namespace.php
@@ -8,8 +8,8 @@
 namespace Altis\Cloud\CloudWatch_Logs;
 
 use Altis;
-use Aws\Exception\AwsException;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Aws\Exception\AwsException;
 use Exception;
 
 const OBJECT_CACHE_GROUP = 'cloudwatch-stream-tokens';

--- a/inc/cloudwatch_logs/namespace.php
+++ b/inc/cloudwatch_logs/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis\Cloud\CloudWatch_Logs;
 
 use Altis;
+use Aws\Exception\AwsException;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Exception;
 
@@ -50,14 +51,15 @@ function send_events_to_stream( array $events, string $group, string $stream ) {
 					'logStreamName' => $stream,
 				]);
 			} else {
-				$next_token = $streams[0]['uploadSequenceToken'];
+				if ( isset( $streams[0]['uploadSequenceToken'] ) ) {
+					$next_token = $streams[0]['uploadSequenceToken'];
+				}
 			}
 		} catch ( Exception $e ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			trigger_error( $e->getMessage(), E_USER_WARNING );
 		}
 	}
-
 	$params = [
 		'logEvents' => $events,
 		'logGroupName' => $group,
@@ -69,6 +71,21 @@ function send_events_to_stream( array $events, string $group, string $stream ) {
 	try {
 		$result = cloudwatch_logs_client()->putLogEvents( $params );
 		wp_cache_set( $group . $stream, $result['nextSequenceToken'], OBJECT_CACHE_GROUP );
+	} catch ( AwsException $e ) {
+		// If the error was an InvalidSequenceTokenException, we can reset the token and try again.
+		if ( $e->getAwsErrorCode() === 'InvalidSequenceTokenException' ) {
+			$expected_sequence_token = $e['expectedSequenceToken'] ?? null;
+			// If the expectedSequence token is set, update the cache. If not, delete the sequence token from the cache.
+			if ( $expected_sequence_token ) {
+				wp_cache_set( $group . $stream, $expected_sequence_token, OBJECT_CACHE_GROUP );
+			} else {
+				wp_cache_delete( $group . $stream, OBJECT_CACHE_GROUP );
+			}
+			return send_events_to_stream( $events, $group, $stream );
+		}
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( $e->getMessage(), E_USER_WARNING );
+		wp_cache_delete( $group . $stream, OBJECT_CACHE_GROUP );
 	} catch ( Exception $e ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		trigger_error( $e->getMessage(), E_USER_WARNING );

--- a/tests/class-test-cloudwatch-logs.php
+++ b/tests/class-test-cloudwatch-logs.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Altis\Cloud\Tests;
+
+use Altis\Cloud\CloudWatch_Logs;
+use Aws\CommandInterface;
+use Aws\Exception\AwsException;
+use Aws\MockHandler;
+use Aws\Result;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class Test_CloudWatch_Logs extends TestCase {
+	/**
+	 * SDK mock handler.
+	 *
+	 * @see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_handlers-and-middleware.html
+	 *
+	 * @var MockHandler
+	 */
+	protected $sdk_mock;
+
+	public function setUp() {
+		$this->sdk_mock = new MockHandler();
+		tests_add_filter( 'altis.aws_sdk.params', function ( array $params ) : array {
+			$params['handler'] = $this->sdk_mock;
+			return $params;
+		} );
+	}
+	public function test_send_events_to_stream_invalid_cached_sequence_token() {
+		// Set an initial wrong token in the cache. This will cause the first request to PutLogEvents to fail.
+		wp_cache_set( 'test-stack/phpvar', 'wrong-token', CloudWatch_Logs\OBJECT_CACHE_GROUP );
+		$this->sdk_mock->append( function ( CommandInterface $cmd, RequestInterface $req ) {
+			return new AwsException( 'Mock exception', $cmd, [
+				'code' => 'InvalidSequenceTokenException',
+				'body' => [
+					'expectedSequenceToken' => '1',
+				],
+			] );
+		} );
+		// The next expected request to the AWS SDK is a retry PutLogEvents, this time we respond with the
+		// next valid sequence token.
+		$this->sdk_mock->append( new Result(
+			[ 'nextSequenceToken' => '2' ]
+		) );
+		CloudWatch_Logs\send_events_to_stream( [
+			[
+				'timestamp' => time() * 1000,
+				'message' => 'hello',
+			],
+		], 'test-stack/php', 'var' );
+
+		$new_token = wp_cache_get( 'test-stack/phpvar', CloudWatch_Logs\OBJECT_CACHE_GROUP );
+
+		$this->assertEquals( '2', $new_token );
+	}
+}


### PR DESCRIPTION
In cases when the sequence token in the cache is wrong, we can auto-retry with the new sequence token.

I also added unit tests here, which I'm running from the main platform-dev repo. I will share my approach on that, but in the mean time I don't see an issue per-say with including the unit tests already.

Fixes #168.