### PR TITLE
Update AWS SES mail to 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",
 		"humanmade/batcache": "1.3.3",
 		"stuttter/ludicrousdb": "5.0.0",
-		"humanmade/aws-ses-wp-mail": "1.1.0"
+		"humanmade/aws-ses-wp-mail": "~1.2.0"
 	},
 	"extra": {
 		"altis": {}


### PR DESCRIPTION
Fixes unicode site names in sender header

Fixes #247 