### PR TITLE
[Backport v3-branch] Update AWS SES mail to 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.0.0",
 		"humanmade/batcache": "1.3.3",
 		"stuttter/ludicrousdb": "4.2.0",
-		"humanmade/aws-ses-wp-mail": "1.1.0"
+		"humanmade/aws-ses-wp-mail": "~1.2.0"
 	},
 	"extra": {
 		"altis": {}


### PR DESCRIPTION
Fixes unicode site names in sender header

Backporting #264 