### PR TITLE
Fix Query Monitor output in cloud

### DIFF
--- a/inc/cloudwatch_error_handler/namespace.php
+++ b/inc/cloudwatch_error_handler/namespace.php
@@ -30,7 +30,16 @@ function bootstrap() {
 		return false;
 	} );
 
-	register_shutdown_function( __NAMESPACE__ . '\\send_buffered_errors_on_shutdown' );
+	// Hook into Query Monitor error handler in case the above is overridden.
+	add_action( 'qm/collect/new_php_error', __NAMESPACE__ . '\\error_handler', 10, 5 );
+
+	// Register shutdown function.
+	// Nesting the function registration ensures it is the last shutdown
+	// function to run, required as we call fastcgi_finish_request()
+	// which ends the request before Query Monitor's output.
+	register_shutdown_function( function () {
+		register_shutdown_function( __NAMESPACE__ . '\\send_buffered_errors_on_shutdown' );
+	} );
 }
 
 /**


### PR DESCRIPTION
Looks like this was a regression introduced with the addition of `fastcgi_finish_request()` added to the shutdown function for sending cloudwatch errors. This is the actual fix for https://github.com/humanmade/altis-dev-tools/issues/113

There is an additional PR here to reinstate full Query Monitor capabilities in cloud environments https://github.com/humanmade/altis-dev-tools/pull/116