### PR TITLE
Switch to HM fork of Ludicrous DB

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"humanmade/wp-redis": "0.7.1",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",
 		"humanmade/batcache": "1.3.3",
-		"stuttter/ludicrousdb": "5.0.0",
+		"humanmade/ludicrousdb": "5.0.0",
 		"humanmade/aws-ses-wp-mail": "~1.2.0"
 	},
 	"extra": {


### PR DESCRIPTION
The official package has some recurring issue of tags being deleted. This has happened repeatedly and means Altis cannot be installed so we need to move this into our direct control.