### PR TITLE
Cache S3 upload dirs

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -567,51 +567,51 @@ function set_tachyon_hostname( string $tachyon_url ) : string {
 function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
 	$s3_uploads = S3_Uploads::get_instance();
 
-	$s3_upload_dirs = wp_cache_get( 's3_upload_dirs' );
+	$cached_upload_dirs = wp_cache_get( 's3_upload_dirs' );
 
-	if ( ! $s3_upload_dirs ) {
-		$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
-		$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );
-		$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
-
-		if ( ! $primary_host ) {
-			trigger_error( sprintf( 'Error parsing main site URL: %s', esc_url_raw( get_main_site_url() ) ), E_USER_WARNING );
-			return $dirs;
-		}
-
-		if ( ! $s3_host ) {
-			trigger_error( sprintf( 'Error parsing S3 bucket URL: %s', esc_url_raw( $s3_uploads->get_s3_url() ) ), E_USER_WARNING );
-			return $dirs;
-		}
-
-		if ( ! $current_host ) {
-			trigger_error( sprintf( 'Error parsing site URL: %s', esc_url_raw( site_url() ) ), E_USER_WARNING );
-			return $dirs;
-		}
-
-		// To support 3rd party CDNs leave the host names as is if the direct
-		// amazonaws.com URL is in use.
-		if ( strpos( $s3_host, '.amazonaws.com' ) !== false ) {
-			return $dirs;
-		}
-
-		// Ensure uploads host at least matches primary site host.
-		if ( $s3_host !== $primary_host ) {
-			$dirs['url'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['url'] );
-			$dirs['baseurl'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['baseurl'] );
-		}
-
-		// Only do the replacement if the host name is not a subdomain of the S3 host.
-		if ( substr( $current_host, -1 * strlen( $primary_host ) ) !== $primary_host ) {
-			$dirs['url'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['url'] );
-			$dirs['baseurl'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['baseurl'] );
-		}
-
-		$s3_upload_dirs = $dirs;
-		wp_cache_set( 's3_upload_dirs', $s3_upload_dirs );
+	if ( $cached_upload_dirs ) {
+		return $cached_upload_dirs;
 	}
 
-	return $s3_upload_dirs;
+	$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
+	$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );
+	$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
+
+	if ( ! $primary_host ) {
+		trigger_error( sprintf( 'Error parsing main site URL: %s', esc_url_raw( get_main_site_url() ) ), E_USER_WARNING );
+		return $dirs;
+	}
+
+	if ( ! $s3_host ) {
+		trigger_error( sprintf( 'Error parsing S3 bucket URL: %s', esc_url_raw( $s3_uploads->get_s3_url() ) ), E_USER_WARNING );
+		return $dirs;
+	}
+
+	if ( ! $current_host ) {
+		trigger_error( sprintf( 'Error parsing site URL: %s', esc_url_raw( site_url() ) ), E_USER_WARNING );
+		return $dirs;
+	}
+
+	// To support 3rd party CDNs leave the host names as is if the direct
+	// amazonaws.com URL is in use.
+	if ( strpos( $s3_host, '.amazonaws.com' ) !== false ) {
+		return $dirs;
+	}
+
+	// Ensure uploads host at least matches primary site host.
+	if ( $s3_host !== $primary_host ) {
+		$dirs['url'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['url'] );
+		$dirs['baseurl'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['baseurl'] );
+	}
+
+	// Only do the replacement if the host name is not a subdomain of the S3 host.
+	if ( substr( $current_host, -1 * strlen( $primary_host ) ) !== $primary_host ) {
+		$dirs['url'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['url'] );
+		$dirs['baseurl'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['baseurl'] );
+	}
+
+	wp_cache_set( 's3_upload_dirs', $dirs );
+	return $dirs;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -561,21 +561,24 @@ function set_tachyon_hostname( string $tachyon_url ) : string {
 /**
  * Ensure the S3 Uploads Bucket URL matches the current site hostname.
  *
+ * Because this filter involves switching blogs, the results are cached in a
+ * static variable for performance.
+ *
  * @param array $dirs Uploads directories array.
  * @return array
  */
 function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
-	$s3_uploads = S3_Uploads::get_instance();
-
-	$cached_upload_dirs = wp_cache_get( 's3_upload_dirs' );
+	static $cached_upload_dirs = null;
 
 	if ( $cached_upload_dirs ) {
 		return $cached_upload_dirs;
 	}
 
+	$s3_uploads = S3_Uploads::get_instance();
+
+	$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
 	$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
 	$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );
-	$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
 
 	if ( ! $primary_host ) {
 		trigger_error( sprintf( 'Error parsing main site URL: %s', esc_url_raw( get_main_site_url() ) ), E_USER_WARNING );
@@ -610,7 +613,9 @@ function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
 		$dirs['baseurl'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['baseurl'] );
 	}
 
-	wp_cache_set( 's3_upload_dirs', $dirs );
+	// Store dirs as non-persistant cache entry.
+	$cached_upload_dirs = $dirs;
+
 	return $dirs;
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -477,7 +477,7 @@ function load_db() {
  * @return string
  */
 function get_main_site_url( string $path = '' ) : string {
-	static $main_site_url = '';
+	static $main_site_url;
 
 	if ( ! $main_site_url ) {
 		$main_site_url = get_site_url( get_main_site_id( get_main_network_id() ) );
@@ -574,7 +574,7 @@ function set_tachyon_hostname( string $tachyon_url ) : string {
  * @return array
  */
 function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
-	static $cached_upload_dirs = null;
+	static $cached_upload_dirs;
 
 	if ( $cached_upload_dirs ) {
 		return $cached_upload_dirs;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -576,9 +576,9 @@ function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
 
 	$s3_uploads = S3_Uploads::get_instance();
 
-	$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
 	$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
 	$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );
+	$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
 
 	if ( ! $primary_host ) {
 		trigger_error( sprintf( 'Error parsing main site URL: %s', esc_url_raw( get_main_site_url() ) ), E_USER_WARNING );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -477,7 +477,13 @@ function load_db() {
  * @return string
  */
 function get_main_site_url( string $path = '' ) : string {
-	return get_site_url( get_main_site_id( get_main_network_id() ), $path );
+	static $main_site_url = '';
+
+	if ( ! $main_site_url ) {
+		$main_site_url = get_site_url( get_main_site_id( get_main_network_id() ) );
+	}
+
+	return path_join( $main_site_url, $path );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -567,44 +567,51 @@ function set_tachyon_hostname( string $tachyon_url ) : string {
 function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
 	$s3_uploads = S3_Uploads::get_instance();
 
-	$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
-	$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );
-	$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
+	$s3_upload_dirs = wp_cache_get( 's3_upload_dirs' );
 
-	if ( ! $primary_host ) {
-		trigger_error( sprintf( 'Error parsing main site URL: %s', esc_url_raw( get_main_site_url() ) ), E_USER_WARNING );
-		return $dirs;
+	if ( ! $s3_upload_dirs ) {
+		$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
+		$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );
+		$current_host = wp_parse_url( site_url(), PHP_URL_HOST );
+
+		if ( ! $primary_host ) {
+			trigger_error( sprintf( 'Error parsing main site URL: %s', esc_url_raw( get_main_site_url() ) ), E_USER_WARNING );
+			return $dirs;
+		}
+
+		if ( ! $s3_host ) {
+			trigger_error( sprintf( 'Error parsing S3 bucket URL: %s', esc_url_raw( $s3_uploads->get_s3_url() ) ), E_USER_WARNING );
+			return $dirs;
+		}
+
+		if ( ! $current_host ) {
+			trigger_error( sprintf( 'Error parsing site URL: %s', esc_url_raw( site_url() ) ), E_USER_WARNING );
+			return $dirs;
+		}
+
+		// To support 3rd party CDNs leave the host names as is if the direct
+		// amazonaws.com URL is in use.
+		if ( strpos( $s3_host, '.amazonaws.com' ) !== false ) {
+			return $dirs;
+		}
+
+		// Ensure uploads host at least matches primary site host.
+		if ( $s3_host !== $primary_host ) {
+			$dirs['url'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['url'] );
+			$dirs['baseurl'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['baseurl'] );
+		}
+
+		// Only do the replacement if the host name is not a subdomain of the S3 host.
+		if ( substr( $current_host, -1 * strlen( $primary_host ) ) !== $primary_host ) {
+			$dirs['url'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['url'] );
+			$dirs['baseurl'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['baseurl'] );
+		}
+
+		$s3_upload_dirs = $dirs;
+		wp_cache_set( 's3_upload_dirs', $s3_upload_dirs );
 	}
 
-	if ( ! $s3_host ) {
-		trigger_error( sprintf( 'Error parsing S3 bucket URL: %s', esc_url_raw( $s3_uploads->get_s3_url() ) ), E_USER_WARNING );
-		return $dirs;
-	}
-
-	if ( ! $current_host ) {
-		trigger_error( sprintf( 'Error parsing site URL: %s', esc_url_raw( site_url() ) ), E_USER_WARNING );
-		return $dirs;
-	}
-
-	// To support 3rd party CDNs leave the host names as is if the direct
-	// amazonaws.com URL is in use.
-	if ( strpos( $s3_host, '.amazonaws.com' ) !== false ) {
-		return $dirs;
-	}
-
-	// Ensure uploads host at least matches primary site host.
-	if ( $s3_host !== $primary_host ) {
-		$dirs['url'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['url'] );
-		$dirs['baseurl'] = str_replace( "://{$s3_host}", "://{$primary_host}", $dirs['baseurl'] );
-	}
-
-	// Only do the replacement if the host name is not a subdomain of the S3 host.
-	if ( substr( $current_host, -1 * strlen( $primary_host ) ) !== $primary_host ) {
-		$dirs['url'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['url'] );
-		$dirs['baseurl'] = str_replace( "://{$primary_host}", "://{$current_host}", $dirs['baseurl'] );
-	}
-
-	return $dirs;
+	return $s3_upload_dirs;
 }
 
 /**


### PR DESCRIPTION
Prevents cache thrashing by repeatedly switching to and back from the main blog when building Tachyon URLs for attachments in multisite subsites.

See #312 - work in progress, opening pull request to test only.