### PR TITLE
Fix path_join bug introduced in #313

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -483,7 +483,7 @@ function get_main_site_url( string $path = '' ) : string {
 		$main_site_url = get_site_url( get_main_site_id( get_main_network_id() ) );
 	}
 
-	return path_join( $main_site_url, $path );
+	return path_join( $main_site_url, ltrim( $path, '/' ) );
 }
 
 /**


### PR DESCRIPTION
Ugh, I'm sorry here. :facepalm: 

I didn't fully test after the last commit in #313, and ended up breaking the whole Media Library.

If the second argument passed into `path_join()` has a leading slash, WP will treat it as an absolute path and just return it unchanged. So `Altis\Cloud\get_main_site_url( '/2020/02/19/yolo.gif' )` just returns '/2020/02/19/yolo.gif', rather than a fully qualified Tachyon URL.

This fixes that problem by removing the leading slash.