### PR TITLE
Update to S3 Uploads alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"php": ">=7.1",
 		"humanmade/wp-redis-predis-client": "0.1.0",
 		"humanmade/aws-xray": "~1.2.7",
-		"humanmade/s3-uploads": "~2.1",
+		"humanmade/s3-uploads": "^3.0.0-alpha",
 		"humanmade/cavalcade": "^2.0.0",
 		"humanmade/wp-redis": "0.7.1",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -580,7 +580,7 @@ function set_s3_uploads_bucket_url_hostname( array $dirs ) : array {
 		return $cached_upload_dirs;
 	}
 
-	$s3_uploads = S3_Uploads::get_instance();
+	$s3_uploads = S3_Uploads\Plugin::get_instance();
 
 	$primary_host = wp_parse_url( get_main_site_url(), PHP_URL_HOST );
 	$s3_host = wp_parse_url( $s3_uploads->get_s3_url(), PHP_URL_HOST );


### PR DESCRIPTION
S3 Uploads has a lot of breaking changes but also performance improvements and opens up features like private uploads. Will be good start stress testing it.

This PR can be backed out of the v7 release if necessary.