### PR TITLE
Update minimum S3 Uploads version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"php": ">=7.1",
 		"humanmade/wp-redis-predis-client": "0.1.0",
 		"humanmade/aws-xray": "~1.2.7",
-		"humanmade/s3-uploads": "~2.1",
+		"humanmade/s3-uploads": "~2.3.0",
 		"humanmade/cavalcade": "^2.0.0",
 		"humanmade/wp-redis": "0.7.1",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",


### PR DESCRIPTION
Makes Altis Cloud PHP 7.4+ compatible.

Fixes #314