### PR TITLE
Fix redis healthcheck

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -532,7 +532,7 @@ function load_plugins() {
 	}
 
 	if ( $config['healthcheck'] ) {
-		add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_healthcheck' );
+		add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_healthcheck', 100 );
 	}
 
 	// Bootstrap integration with Elasticsearch Service API.


### PR DESCRIPTION
This is an effort to make the healthcheck backwards compatible in case wp-redis changes the stats method behaviour.