### PR TITLE
Use clear scheduled hook to remove package status check

### DIFF
--- a/inc/elasticsearch_packages/namespace.php
+++ b/inc/elasticsearch_packages/namespace.php
@@ -326,10 +326,7 @@ function on_check_package_status( string $package_id, string $slug, bool $for_ne
 		}
 
 		// Unschedule this status check.
-		$next = wp_next_scheduled( 'altis.search.check_package_status', $check_status_hook_args );
-		if ( $next ) {
-			wp_unschedule_event( $next, 'altis.search.check_package_status', $check_status_hook_args );
-		}
+		wp_clear_scheduled_hook( 'altis.search.check_package_status', $check_status_hook_args );
 
 		// Schedule the index settings update.
 		if ( ! wp_next_scheduled( 'altis.search.update_index_settings', $update_index_hook_args ) ) {
@@ -337,10 +334,7 @@ function on_check_package_status( string $package_id, string $slug, bool $for_ne
 		}
 	} catch ( Exception $e ) {
 		// Unschedule this hook.
-		$next = wp_next_scheduled( 'altis.search.check_package_status', $check_status_hook_args );
-		if ( $next ) {
-			wp_unschedule_event( $next, 'altis.search.check_package_status', $check_status_hook_args );
-		}
+		wp_clear_scheduled_hook( 'altis.search.check_package_status', $check_status_hook_args );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		trigger_error( $e->getMessage(), E_USER_WARNING );


### PR DESCRIPTION
The `wp_next_scheduled()` response appears to be subject to caching so for custom cron job intervals such as 1 minute in this case the next scheduled time can be too old for it to ever match the actual next event. This means the current method for clearing the scheduled task fails silently.

Using clear scheduled hook is more appropriate here because it is the arguments that are unique to the task.

Fixes #379