### PR TITLE
replace the hm logo with the altis logo

### DIFF
--- a/inc/healthcheck/namespace.php
+++ b/inc/healthcheck/namespace.php
@@ -79,7 +79,7 @@ function output_page( array $checks ) {
 		<head>
 			<title>Status: <?php echo $passed ? 'OK' : 'Failure!' ?></title>
 		</head>
-		<img src="https://humanmade.github.io/hm-pattern-library/assets/images/logos/logo-small-red.svg" style="height: 30px; vertical-align: middle" />
+		<img src="https://make.hmn.md/altis/Altis-logo.svg" style="height: 30px; vertical-align: middle" />
 		<table>
 			<?php foreach ( $checks as $check => $status ) : ?>
 				<tr>


### PR DESCRIPTION
Replaces the Human Made logo with the Altis logo in the healthcheck component.

I'm not sure where this logo/page is actually located or how it's accessed. I don't see anything locally or on on platform-test at the `domain.com/healthcheck/` endpoint and I don't see anything in Vantage either, so I can't actually test/confirm that this is working, in the off chance that there's another place the logo is used.

Fixes #151 