### PR TITLE
Link directly to the X-Ray trace

### DIFF
--- a/assets/environment-indicator.css
+++ b/assets/environment-indicator.css
@@ -22,7 +22,7 @@
 	line-height: inherit;
 }
 
-#wpadminbar #wp-admin-bar-altis .dashicons-before::before {
+#wpadminbar .ab-submenu .ab-item .dashicons-before::before {
 	font-size: 16px; /* stylelint-disable-line declaration-property-unit-blacklist */
 	vertical-align: middle;
 }

--- a/docs/dashboard/x-ray.md
+++ b/docs/dashboard/x-ray.md
@@ -4,6 +4,8 @@ The Altis Dashboard provides a way to view all backend PHP requests for develope
 
 XRay traces provide performance profiling, database queries, remote requests and exposes all request data for each backend PHP request.
 
+You can jump directly to the XRay trace for the current request by clicking the "Debug Request" link in the Query Monitor menu or the Altis logo menu in the admin bar.
+
 <video controls src="https://www.altis-dxp.com/uploads/2020/07/altis-cloud-dashboard-xray.mp4"></video>
 
 ## Searching XRay Requests

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -27,6 +27,7 @@ use Monolog\Logger;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use S3_Uploads;
+use WP_Admin_Bar;
 use WP_CLI;
 
 /**
@@ -64,6 +65,7 @@ function bootstrap() {
 	) {
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/inc/namespace.php';
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/plugin.php';
+		add_action( 'admin_bar_menu', __NAMESPACE__ . '\\register_trace_menu_item', 100 );
 		add_filter( 'aws_xray.redact_metadata', __NAMESPACE__ . '\\remove_xray_metadata' );
 		if ( in_array( Altis\get_environment_architecture(), [ 'ec2', 'ecs' ], true ) ) {
 			add_filter( 'aws_xray.trace_to_daemon', __NAMESPACE__ . '\\add_ec2_instance_data_to_xray' );
@@ -1083,4 +1085,33 @@ function get_logger( string $log_group, string $log_stream ) : LoggerInterface {
 
 	$loggers[ $tag_name ] = $logger;
 	return $loggers[ $tag_name ];
+}
+
+/**
+ * Register the "Debug Request" menu item.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
+ */
+function register_trace_menu_item( WP_Admin_Bar $wp_admin_bar ) {
+	if ( ! defined( 'HM_ENV_REGION' ) ) {
+		return;
+	}
+
+	$trace_id = XRay\get_root_trace_id();
+	$url = sprintf(
+		'https://dashboard.altis-dxp.com/#/%s/%s/xray/trace/%s',
+		HM_ENV_REGION,
+		Altis\get_environment_name(),
+		$trace_id
+	);
+
+	$title = __( 'Debug Request', 'altis' );
+	$logo_menu_args = [
+		'id' => 'altis-view-trace',
+		'parent' => 'altis',
+		'title' => $title . ' <span class="dashicons-before dashicons-external"></span>',
+		'href' => $url,
+	];
+
+	$wp_admin_bar->add_menu( $logo_menu_args );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -66,6 +66,8 @@ function bootstrap() {
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/inc/namespace.php';
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/aws-xray/plugin.php';
 		add_action( 'admin_bar_menu', __NAMESPACE__ . '\\register_trace_menu_item', 100 );
+		add_filter( 'qm/output/menus', __NAMESPACE__ . '\\register_trace_qm_menu_item' );
+		add_filter( 'qm/output/panel_menus', __NAMESPACE__ . '\\register_trace_qm_panel_menu_item', 41 );
 		add_filter( 'aws_xray.redact_metadata', __NAMESPACE__ . '\\remove_xray_metadata' );
 		if ( in_array( Altis\get_environment_architecture(), [ 'ec2', 'ecs' ], true ) ) {
 			add_filter( 'aws_xray.trace_to_daemon', __NAMESPACE__ . '\\add_ec2_instance_data_to_xray' );
@@ -1088,22 +1090,34 @@ function get_logger( string $log_group, string $log_stream ) : LoggerInterface {
 }
 
 /**
- * Register the "Debug Request" menu item.
+ * Get the current XRay trace URL on Vantage.
  *
- * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
+ * @return string
  */
-function register_trace_menu_item( WP_Admin_Bar $wp_admin_bar ) {
-	if ( ! defined( 'HM_ENV_REGION' ) ) {
-		return;
+function get_xray_trace_url() : string {
+	if ( ! is_cloud() || ! defined( 'HM_ENV_REGION' ) ) {
+		return '';
 	}
 
 	$trace_id = XRay\get_root_trace_id();
-	$url = sprintf(
+	return sprintf(
 		'https://dashboard.altis-dxp.com/#/%s/%s/xray/trace/%s',
 		HM_ENV_REGION,
 		Altis\get_environment_name(),
 		$trace_id
 	);
+}
+
+/**
+ * Register the "Debug Request" menu item.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
+ */
+function register_trace_menu_item( WP_Admin_Bar $wp_admin_bar ) {
+	$url = get_xray_trace_url();
+	if ( empty( $url ) ) {
+		return;
+	}
 
 	$title = __( 'Debug Request', 'altis' );
 	$logo_menu_args = [
@@ -1114,4 +1128,39 @@ function register_trace_menu_item( WP_Admin_Bar $wp_admin_bar ) {
 	];
 
 	$wp_admin_bar->add_menu( $logo_menu_args );
+}
+
+/**
+ * Add the dashboard trace URL to the QM panel menu.
+ *
+ * @param array $menu The Query Monitor panel menu.
+ * @return array
+ */
+function register_trace_qm_menu_item( array $menu ) : array {
+	$url = get_xray_trace_url();
+	if ( empty( $url ) ) {
+		return $menu;
+	}
+
+	$menu['aws-xray-trace'] = [
+		'title' => __( 'Debug in Altis Dashboard', 'altis' ) . ' <span class="dashicons-before dashicons-external"></span>',
+		'id' => 'query-monitor-aws-xray-dashboard',
+		'href' => $url,
+	];
+
+	return $menu;
+}
+
+/**
+ * Add the dashboard trace URL to the QM panel menu.
+ *
+ * @param array $menu The Query Monitor panel menu.
+ * @return array
+ */
+function register_trace_qm_panel_menu_item( array $menu ) : array {
+	// Admin bar menu items are duplicated in the QM panel menu so we
+	// remove it here as external links aren't supported.
+	unset( $menu['aws-xray-trace'] );
+
+	return $menu;
 }


### PR DESCRIPTION
This allows viewing the request trace directly, useful if you're on production without the dev tools enabled.