### PR TITLE
Correction to the configuration documentation

### DIFF
--- a/docs/page-caching.md
+++ b/docs/page-caching.md
@@ -214,7 +214,7 @@ For developing cache customizations locally, you may wish to enable Batcache for
 				"local": {
 					"modules": {
 						"cloud": {
-							"batcache": false
+							"batcache": true
 						}
 					}
 				}


### PR DESCRIPTION
By default Batcache is not on local environments. For developing cache customizations locally, you may wish to enable Batcache for local environments.

The example in the documentation is `"batcache": false`, where it should be `"batcache": true`.