### PR TITLE
Healthchecks for alloptions / notoptions sizes

### DIFF
--- a/inc/healthcheck/namespace.php
+++ b/inc/healthcheck/namespace.php
@@ -245,6 +245,15 @@ function run_object_cache_healthcheck() {
 		}
 	}
 
+	if ( strlen( serialize( $alloptions_cache ) ) > 1024 * 1024 ) { // 1MB
+		return new WP_Error( 'object-cache-alloptions-too-large', sprintf( 'alloptions cache key too large (%d bytes)', strlen( serialize( $alloptions_cache ) ) ) );
+	}
+
+	$notoptions = wp_cache_get( 'notoptions', 'options' );
+	if ( strlen( serialize( $notoptions ) ) > 1024 * 1024 ) { // 1MB
+		return new WP_Error( 'object-cache-notoptions-too-large', sprintf( 'notoptions cache key too large (%d bytes)', strlen( serialize( $notoptions ) ) ) );
+	}
+
 	return true;
 }
 

--- a/inc/healthcheck/namespace.php
+++ b/inc/healthcheck/namespace.php
@@ -245,13 +245,15 @@ function run_object_cache_healthcheck() {
 		}
 	}
 
-	if ( strlen( serialize( $alloptions_cache ) ) > 1024 * 1024 ) { // 1MB
-		return new WP_Error( 'object-cache-alloptions-too-large', sprintf( 'alloptions cache key too large (%d bytes)', strlen( serialize( $alloptions_cache ) ) ) );
+	$alloptions_cache_size = strlen( serialize( $alloptions_cache ) );
+	if ( $alloptions_cache_size > 1024 * 1024 ) { // 1MB
+		return new WP_Error( 'object-cache-alloptions-too-large', sprintf( 'alloptions cache key too large (%d bytes)', $alloptions_cache_size ) );
 	}
 
 	$notoptions = wp_cache_get( 'notoptions', 'options' );
-	if ( strlen( serialize( $notoptions ) ) > 1024 * 1024 ) { // 1MB
-		return new WP_Error( 'object-cache-notoptions-too-large', sprintf( 'notoptions cache key too large (%d bytes)', strlen( serialize( $notoptions ) ) ) );
+	$notoptions_cache_size = strlen( serialize( $notoptions ) );
+	if ( $notoptions_cache_size > 1024 * 1024 ) { // 1MB
+		return new WP_Error( 'object-cache-notoptions-too-large', sprintf( 'notoptions cache key too large (%d bytes)', $notoptions_cache_size ) );
 	}
 
 	return true;


### PR DESCRIPTION
We recently ran into a case when notoptions was very large, I don't believe there's a good reason these cache keys should be so large.
