### PR TITLE
Update Ludicrous DB to 5.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"humanmade/wp-redis": "1.1.2",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",
 		"humanmade/batcache": "~1.4.0",
-		"humanmade/ludicrousdb": "5.0.0",
+		"humanmade/ludicrousdb": "~5.0.1",
 		"humanmade/aws-ses-wp-mail": "~1.3.0",
 		"monolog/monolog": "^2.3",
 		"maxbanton/cwh": "^2.0"


### PR DESCRIPTION
Adds the tilde version constraint as well.