### PR TITLE
[Backport v9-branch] Update humanmade/ludicrousdb requirement from ~5.0.1 to ~5.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"humanmade/wp-redis": "1.1.2",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",
 		"humanmade/batcache": "~1.3.4",
-		"humanmade/ludicrousdb": "5.0.0",
+		"humanmade/ludicrousdb": "~5.0.2",
 		"humanmade/aws-ses-wp-mail": "~1.2.0",
 		"monolog/monolog": "^2.3",
 		"maxbanton/cwh": "^2.0"


### PR DESCRIPTION
Backporting #557

---------------

Updates the requirements on [humanmade/ludicrousdb](https://github.com/humanmade/ludicrousdb) to permit the latest version.
- [Release notes](https://github.com/humanmade/ludicrousdb/releases)
- [Commits](https://github.com/humanmade/ludicrousdb/compare/5.0.1...5.0.2)

---
updated-dependencies:
- dependency-name: humanmade/ludicrousdb
  dependency-type: direct:production
...