### PR TITLE
Update docs to remove v8js and xhprof from available modules list

### DIFF
--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -59,9 +59,7 @@ order: 100
 - sysvsem
 - sysvshm
 - tokenizer
-- v8js
 - wddx
-- xhprof
 - xml
 - xmlreader
 - xmlwriter

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -59,6 +59,7 @@ order: 100
 - sysvsem
 - sysvshm
 - tokenizer
+- v8js (experimental)
 - wddx
 - xml
 - xmlreader


### PR DESCRIPTION
Ref https://github.com/humanmade/docker-wordpress-php/issues/106