### PR TITLE
Correct the reference to `mysqli` so database error code appears correctly in QM

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -76,7 +76,7 @@ class DB extends LudicrousDB {
 		if ( $this->last_error ) {
 			$code = 'qmdb';
 			if ( $this->use_mysqli ) {
-				if ( $this->dbh instanceof mysqli ) {
+				if ( $this->dbh instanceof \mysqli ) {
 					// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_errno
 					$code = mysqli_errno( $this->dbh );
 				}


### PR DESCRIPTION
When a database query results in an error, the generic `qmdb` error code is shown in Query Monitor instead of the actual error code from MySQL. This is because the reference to `mysqli` isn't namespaced correctly.

Before:

<img width="131" alt="" src="https://user-images.githubusercontent.com/208434/166557540-4f0156a4-d24d-49ec-a933-04c91d56899c.png">

After:

<img width="130" alt="" src="https://user-images.githubusercontent.com/208434/166557547-022ad75b-e652-4409-a1c3-22c803ea7f8d.png">
