### PR TITLE
Bootstrap XRay if Excimer is available

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -57,10 +57,11 @@ function bootstrap() {
 	$config = get_config();
 
 	$is_alb_healthcheck = isset( $_SERVER['HTTP_USER_AGENT'] ) && strpos( $_SERVER['HTTP_USER_AGENT'], 'ELB-HealthChecker' ) === 0;
+	$has_profiler = class_exists( 'ExcimerProfiler' ) || function_exists( 'xhprof_sample_enable' );
 
 	if (
 		$config['xray']
-		&& function_exists( 'xhprof_sample_enable' )
+		&& $has_profiler
 		&& php_sapi_name() !== 'cli'
 		&& ! class_exists( 'HM\\Cavalcade\\Runner\\Runner' )
 		&& ! $is_alb_healthcheck


### PR DESCRIPTION
Currently XRay is bootstrapped only if XHProf is available, which we no longer build for PHP 8.0 and above. The upstream XRay plugin supports the newer Excimer profiler that is PHP 8.0+ compatible. This change bootstraps the plugin if either of the two profilers is available.