### PR TITLE
Ensure `SAVEQUERIES` is defined before checking its value

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -12,8 +12,6 @@ use LudicrousDB;
 use QM_Backtrace;
 use WP_Error;
 
-const SAVEQUERIES = true;
-
 /**
  * Ludicrous DB integration class.
  *
@@ -62,11 +60,11 @@ class DB extends LudicrousDB {
 		$end = microtime( true );
 		$this->time_spent += $end - $start;
 
-		if ( ! $has_qm || ! SAVEQUERIES ) {
+		if ( ! is_array( $this->queries ) || ! $has_qm || ! defined( 'SAVEQUERIES' ) || ! SAVEQUERIES ) {
 			return $result;
 		}
 
-		$i = count( (array) $this->queries ) - 1;
+		$i = count( $this->queries ) - 1;
 		$this->queries[ $i ]['trace'] = new QM_Backtrace( [
 			'ignore_frames' => 1,
 		] );

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -12,6 +12,8 @@ use LudicrousDB;
 use QM_Backtrace;
 use WP_Error;
 
+const SAVEQUERIES = true;
+
 /**
  * Ludicrous DB integration class.
  *
@@ -64,7 +66,7 @@ class DB extends LudicrousDB {
 			return $result;
 		}
 
-		$i = count( $this->queries ) - 1;
+		$i = count( (array) $this->queries ) - 1;
 		$this->queries[ $i ]['trace'] = new QM_Backtrace( [
 			'ignore_frames' => 1,
 		] );


### PR DESCRIPTION
Originally identified in - https://github.com/humanmade/altis-documentation/pull/425

---


Running `composer dev-tools codecept -p  packages/documentation/tests run -vvv` I was able to identify the first error:
```php
PHP Fatal error:  Uncaught Error: Undefined constant "Altis\Cloud\SAVEQUERIES" in /usr/src/app/packages/cloud/inc/class-db.php:63
```

After applying the fix for it, the following error came up:
```php
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /usr/src/app/packages/cloud/inc/class-db.php:69
```
Applying the two fixes above allows `composer dev-tools codecept -p  packages/documentation/tests run -vvv` to run smoothly.