### PR TITLE
Return a mock scheduled event object when preventing cron scheduling

### DIFF
--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -73,5 +73,9 @@ function schedule_events_in_admin( $pre, string $hook ) {
 		return $pre;
 	}
 
-	return true;
+	// Non-empty filter return values are expected by wp_next_scheduled to have
+	// a numeric ->timestamp property.
+	return (object) [
+		'timestamp' => time() + HOUR_IN_SECONDS,
+	];
 }


### PR DESCRIPTION
Based on discussion in #702, this PR proposes an alternative return value which effectively prevents event scheduling.

In almost all cases within Core `true` would have been a valid value for `timestamp`, as it is almost always used in purely boolean checks. However there are one or two specific instances (`wp_version_check`, e.g.) where the timestamp is used in a numeric comparison. Returning an object with a timestamp perpetually one hour in the future feels like a viable hack to prevent event rescheduling.