### PR TITLE
Update Composer version

### DIFF
--- a/docs/build-scripts/README.md
+++ b/docs/build-scripts/README.md
@@ -41,7 +41,7 @@ Your build script can run any commands you'd like, including installing or confi
 The following build tools are pre-installed inside the build container for your script:
 
 - PHP 7.4
-- Composer 1.10
+- Composer 2.4.4
 - Node 12.18
 - npm 6.14
 - Git 2.25


### PR DESCRIPTION
According to `composer --version` inside a `.build-script` file, Composer is now at version 2.4.4 on the cloud deployment infrastructure.