### PR TITLE
Update QM database driver integration

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -64,29 +64,27 @@ class DB extends LudicrousDB {
 			return $result;
 		}
 
-		$i = count( $this->queries ) - 1;
-		$this->queries[ $i ]['trace'] = new QM_Backtrace( [
-			'ignore_frames' => 1,
-		] );
+		$i = $this->num_queries - 1;
+
+		if ( did_action( 'qm/cease' ) ) {
+			// It's not possible to prevent the parent class from logging queries because it reads
+			// the `SAVEQUERIES` constant and I don't want to override more methods than necessary.
+			$this->queries = array();
+		}
+
+		if ( ! isset( $this->queries[ $i ] ) ) {
+			return $result;
+		}
+
+		$this->queries[ $i ]['trace'] = new QM_Backtrace();
 
 		if ( ! isset( $this->queries[ $i ][3] ) ) {
 			$this->queries[ $i ][3] = $this->time_start;
 		}
 
 		if ( $this->last_error ) {
-			$code = 'qmdb';
-			if ( $this->use_mysqli ) {
-				if ( $this->dbh instanceof \mysqli ) {
-					// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_errno
-					$code = mysqli_errno( $this->dbh );
-				}
-			} else {
-				if ( is_resource( $this->dbh ) ) {
-					// Please do not report this code as a PHP 7 incompatibility. Observe the surrounding logic.
-					// phpcs:ignore
-					$code = mysql_errno( $this->dbh );
-				}
-			}
+			$code = mysqli_errno( $this->dbh );
+
 			$this->queries[ $i ]['result'] = new WP_Error( $code, $this->last_error );
 		} else {
 			$this->queries[ $i ]['result'] = $result;


### PR DESCRIPTION
Three updates to the integration with Query Monitor within the database driver:

1. Support for the `qm/cease` action which allows data collection to be ceased entirely, for example when performing long-running actions
  - [Ref](https://github.com/johnbillion/query-monitor/blob/1b89569159856d5b72302d178a567753943dbaac/classes/DB.php#L32-L40)
  - Introduced in QM 3.8.0
2. Removal of the redundant `ignore_frames` parameter in `QM_Backtrace` because `Altis\Cloud\DB` is now ignored internally within QM
  - [Ref](https://github.com/johnbillion/query-monitor/blob/1b89569159856d5b72302d178a567753943dbaac/classes/Backtrace.php#L26)
  - Introduced in QM 3.10.0
3. Simplification of query error code detection, we don't need to worry about anything that isn't `mysqli`