### PR TITLE
Clarify asdf and nvm

### DIFF
--- a/docs/build-scripts/README.md
+++ b/docs/build-scripts/README.md
@@ -51,7 +51,7 @@ The following build tools are pre-installed inside the build container for your 
 
 [asdf]: https://github.com/asdf-vm/asdf
 
-You can install other versions using build tools such as [nvm](https://github.com/nvm-sh/nvm) for Node versions.
+Note that [nvm](https://github.com/nvm-sh/nvm) is not installed by default because asdf provides the same functionality.
 
 
 ## Example build scripts


### PR DESCRIPTION
I see that nvm is being installed and used in the deploy script on several projects where the included asdf could just be used instead. This clarifies the docs in that regard.