### PR TITLE
Add a WP Cache session handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 			"inc/cloudfront_media_purge/namespace.php",
 			"inc/fluent_bit/namespace.php",
 			"inc/session_handler/class-disallowed-session-handler.php",
+			"inc/session_handler/class-wp-cache-session-handler.php",
 			"inc/class-loggerexceptionhandler.php",
 			"inc/namespace.php",
 			"wp-config.php"

--- a/inc/session_handler/class-wp-cache-session-handler.php
+++ b/inc/session_handler/class-wp-cache-session-handler.php
@@ -72,9 +72,9 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	 *
 	 * @param string $id Session id
 	 *
-	 * @return string|false
+	 * @return string
 	 */
-	public function read( string $id ) : string | false {
+	public function read( string $id ) : string {
 		$data = wp_cache_get( $id, 'sessions' );
 		if ( ! $data ) {
 			return '';
@@ -103,9 +103,9 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	 *
 	 * @param int $max_lifetime Max lifetime of a session
 	 *
-	 * @return int|bool
+	 * @return int
 	 */
-	public function gc( int $max_lifetime ) : int | false {
+	public function gc( int $max_lifetime ) : int {
 		return 0;
 	}
 }

--- a/inc/session_handler/class-wp-cache-session-handler.php
+++ b/inc/session_handler/class-wp-cache-session-handler.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Altis Cloud Session handler.
+ *
+ * @package altis/cloud
+ */
+
+namespace Altis\Cloud\Session_Handler;
+
+use SessionHandlerInterface;
+
+/**
+ * WP Cache Session Handler.
+ *
+ * Uses the WordPress object cache to store and retrieve session data.
+ */
+class WP_Cache_Session_Handler implements SessionHandlerInterface {
+	protected int $ttl;
+
+	/**
+	 * Initialize the session handler.
+	 */
+	public function __construct() {
+		wp_cache_add_global_groups( 'sessions' );
+		$this->ttl = ini_get( 'session.gc_maxlifetime' );
+	}
+
+	/**
+	 * Initialize a session.
+	 *
+	 * No-op in this session handler as there is nothing to
+	 * initialize, the object cache takes care of all that.
+	 *
+	 * @param string $path
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function open( string $path, string $name ) : bool {
+		return true;
+	}
+
+	/**
+	 * Close the session.
+	 *
+	 * No-op as there is nothing to close.
+	 *
+	 * @return bool
+	 */
+	public function close() : bool {
+		return true;
+	}
+
+	/**
+	 * Destroy a session.
+	 *
+	 * @param string $id
+	 *
+	 * @return bool
+	 */
+	public function destroy( string $id ) : bool {
+		return wp_cache_delete( $id, 'sessions' );
+	}
+
+	/**
+	 * Read session data.
+	 *
+	 * @param string $id
+	 *
+	 * @return string|false
+	 */
+	public function read( string $id ) : string | false {
+		$data = wp_cache_get( $id, 'sessions' );
+		if ( ! $data ) {
+			return '';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Write session data.
+	 *
+	 * @param string $id
+	 * @param string $data
+	 *
+	 * @return bool
+	 */
+	public function write( string $id, string $data ) : bool {
+		return wp_cache_set( $id, $data, 'sessions', $this->ttl );
+	}
+
+	/**
+	 * Clean up old essions.
+	 *
+	 * No-op as session expiration is taken care of
+	 * in Redis with our set TTLs.
+	 *
+	 * @return int|bool
+	 */
+	public function gc( int $maxlifetime ) : int | false {
+		return 0;
+	}
+}

--- a/inc/session_handler/class-wp-cache-session-handler.php
+++ b/inc/session_handler/class-wp-cache-session-handler.php
@@ -15,7 +15,12 @@ use SessionHandlerInterface;
  * Uses the WordPress object cache to store and retrieve session data.
  */
 class WP_Cache_Session_Handler implements SessionHandlerInterface {
-	protected int $ttl;
+	/**
+	 * The TTL for Redis objects
+	 *
+	 * @var int
+	 */
+	protected $ttl;
 
 	/**
 	 * Initialize the session handler.
@@ -31,8 +36,8 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	 * No-op in this session handler as there is nothing to
 	 * initialize, the object cache takes care of all that.
 	 *
-	 * @param string $path
-	 * @param string $name
+	 * @param string $path Session path
+	 * @param string $name Session name
 	 *
 	 * @return bool
 	 */
@@ -54,7 +59,7 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	/**
 	 * Destroy a session.
 	 *
-	 * @param string $id
+	 * @param string $id Session id
 	 *
 	 * @return bool
 	 */
@@ -65,7 +70,7 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	/**
 	 * Read session data.
 	 *
-	 * @param string $id
+	 * @param string $id Session id
 	 *
 	 * @return string|false
 	 */
@@ -81,8 +86,8 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	/**
 	 * Write session data.
 	 *
-	 * @param string $id
-	 * @param string $data
+	 * @param string $id Session id
+	 * @param string $data Session data
 	 *
 	 * @return bool
 	 */
@@ -91,14 +96,16 @@ class WP_Cache_Session_Handler implements SessionHandlerInterface {
 	}
 
 	/**
-	 * Clean up old essions.
+	 * Clean up old sessions.
 	 *
 	 * No-op as session expiration is taken care of
 	 * in Redis with our set TTLs.
 	 *
+	 * @param int $max_lifetime Max lifetime of a session
+	 *
 	 * @return int|bool
 	 */
-	public function gc( int $maxlifetime ) : int | false {
+	public function gc( int $max_lifetime ) : int | false {
 		return 0;
 	}
 }


### PR DESCRIPTION
Adds support for PHP sessions with our Afterburner implementation of the WordPress object cache.