### PR TITLE
Update class-cli-command.php

### DIFF
--- a/inc/healthcheck/class-cli-command.php
+++ b/inc/healthcheck/class-cli-command.php
@@ -12,7 +12,7 @@ use WP_CLI;
 use WP_CLI_Command;
 
 /**
- * CLI COmmand to run Altis Healthchecks.
+ * CLI Command to run Altis Healthchecks.
  */
 class CLI_Command extends WP_CLI_Command {
 


### PR DESCRIPTION
This corrects the command description when viewing the help in WP-CLI.

## To test

* Run `composer server cli -- help`

## Screenshot
![2023-05-08-11-37-34](https://user-images.githubusercontent.com/208434/236803465-c58e1aee-771d-4989-9254-557274d34679.png)
