### PR TITLE
Fix cavalcade runner memory usage leak

### DIFF
--- a/inc/cavalcade_runner_to_cloudwatch/namespace.php
+++ b/inc/cavalcade_runner_to_cloudwatch/namespace.php
@@ -177,12 +177,16 @@ function cloudwatch_client() : CloudWatchClient {
  * @return CloudWatchLogsClient
  */
 function cloudwatch_logs_client() : CloudWatchLogsClient {
-	return Altis\get_aws_sdk()->createCloudWatchLogs( [
-		'version'     => '2014-03-28',
-		'http'        => [
-			'synchronous' => true,
-		],
-	] );
+	static $client;
+	if ( ! $client ) {
+		$client = Altis\get_aws_sdk()->createCloudWatchLogs( [
+			'version'     => '2014-03-28',
+			'http'        => [
+				'synchronous' => true,
+			],
+		] );
+	}
+	return $client;
 }
 
 /**

--- a/inc/cavalcade_runner_to_cloudwatch/namespace.php
+++ b/inc/cavalcade_runner_to_cloudwatch/namespace.php
@@ -158,12 +158,17 @@ function put_metric_data( $metric_name, $value, $dimensions = [], $unit = 'None'
  * @return CloudWatchClient
  */
 function cloudwatch_client() : CloudWatchClient {
-	return Altis\get_aws_sdk()->createCloudWatch( [
-		'version'     => '2010-08-01',
-		'http'        => [
-			'synchronous' => false,
-		],
-	] );
+	static $client;
+	if ( ! $client ) {
+		$client = Altis\get_aws_sdk()->createCloudWatch( [
+			'version'     => '2010-08-01',
+			'http'        => [
+				'synchronous' => false,
+			],
+		] );
+	}
+
+	return $client;
 }
 
 /**


### PR DESCRIPTION
We recently enabled `opcache.enable_cli` so Cavalcade Runner now has the opcache enabled. This is a bug, it turns out in the opcache whereby including files over and over again will lead to a memory leak. See https://github.com/php/php-src/issues/9812 for details.

This bug causes a very large memory leak in Cavalcade Runner because we naively re-init the Cloudwatchclient on every call to put_metric_data() etc.

So, it makes sense to only create the cloudwatch client once. THis should also drastically reduce the impact of the PHP bug.
