### PR TITLE
URL encode filenames in CDN Media Purge

### DIFF
--- a/inc/cloudfront_media_purge/namespace.php
+++ b/inc/cloudfront_media_purge/namespace.php
@@ -32,7 +32,7 @@ function purge_media_file_cache( int $media_id ) {
 	$upload_path_info = pathinfo( $upload_path );
 	$items            = [];
 	// Make sure the image filename is URL encoded, else CloudFront will not be able to purge it.
-	$items[]          = $upload_path_info['dirname'] . '/' . urlencode( $upload_path_info['filename'] ) . '*';
+	$items[] = $upload_path_info['dirname'] . '/' . urlencode( $upload_path_info['filename'] ) . '*';
 	if ( function_exists( 'tachyon_url' ) ) {
 		$tachyon_url       = tachyon_url( $upload_url );
 		$tachyon_path      = wp_parse_url( $tachyon_url, PHP_URL_PATH );

--- a/inc/cloudfront_media_purge/namespace.php
+++ b/inc/cloudfront_media_purge/namespace.php
@@ -31,7 +31,8 @@ function purge_media_file_cache( int $media_id ) {
 	$upload_path      = wp_parse_url( $upload_url, PHP_URL_PATH );
 	$upload_path_info = pathinfo( $upload_path );
 	$items            = [];
-	$items[]          = $upload_path_info['dirname'] . '/' . $upload_path_info['filename'] . '*';
+	// Make sure the image filename is URL encoded, else CloudFront will not be able to purge it.
+	$items[]          = $upload_path_info['dirname'] . '/' . urlencode( $upload_path_info['filename'] ) . '*';
 	if ( function_exists( 'tachyon_url' ) ) {
 		$tachyon_url       = tachyon_url( $upload_url );
 		$tachyon_path      = wp_parse_url( $tachyon_url, PHP_URL_PATH );


### PR DESCRIPTION
CloudFront will return an error from `createInvalidation` if the URL is not encoded. `tachyon_url()` already does this internally, so is not an issue on the tachyon_url.
