### PR TITLE
Disable PHP language files with Afterburner

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -192,7 +192,7 @@ function load_platform( $wp_debug_enabled ) {
 		load_wp_cache_session_handler();
 		add_filter(
 			'translation_file_format',
-			static function ( string $preferred_format , string $domain ) : string {
+			static function ( string $preferred_format, string $domain ) : string {
 				return 'mo';
 			},
 			10,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -190,6 +190,14 @@ function load_platform( $wp_debug_enabled ) {
 	if ( extension_loaded( 'afterburner' ) ) {
 		load_object_cache_afterburner();
 		load_wp_cache_session_handler();
+		add_filter(
+			'translation_file_format',
+			static function ( string $preferred_format , string $domain ) : string {
+				return 'mo';
+			},
+			10,
+			2
+		);
 	} elseif ( $config['memcached'] ) {
 		load_object_cache_memcached();
 		disable_sessions();


### PR DESCRIPTION
Prefer only `.mo` files for translations if the Afterburner extension is loaded.

References https://github.com/humanmade/product-dev/issues/1546

Before:
![CleanShot 2024-03-29 at 16 56 36](https://github.com/humanmade/altis-cloud/assets/358499/054ee7b7-0191-49ec-9bb7-10d10de744cc)

After:
![CleanShot 2024-03-29 at 17 07 07](https://github.com/humanmade/altis-cloud/assets/358499/43c33c28-d5b4-41d5-bf7b-ed2870d05653)
