### PR TITLE
Define TFA_VERSION from env vars

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -587,9 +587,12 @@ function load_plugins() {
 		define( 'TACHYON_URL', get_main_site_url( '/tachyon' ) );
 	}
 
+	// Define TFA_VERSION from the environment variable.
+	defined( 'TFA_VERSION' ) || define( 'TFA_VERSION', getenv( 'TFA_VERSION' ) ?: '0' );
+
 	// Set the Tachyon Server version if it's not already defined. This is used to flag to Tachyon that we
 	// have a version of Tachyon that supports the newer "presign" query parameter.
-	if ( defined( 'TFA_VERSION' ) && version_compare( TFA_VERSION, '4.6.0', '>=' ) && ! defined( 'TACHYON_SERVER_VERSION' ) ) {
+	if ( version_compare( TFA_VERSION, '4.6.0', '>=' ) && ! defined( 'TACHYON_SERVER_VERSION' ) ) {
 		define( 'TACHYON_SERVER_VERSION', '3.0.0' );
 	}
 


### PR DESCRIPTION
In #863 we assume that TFA_VERSION is defined but we never actually define it. This change defines the constant from the environment variable.