### PR TITLE
Remove v15-branch from checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,12 +44,3 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v16-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v15-branch


### PR DESCRIPTION
Remove EOL v15 branch from dependabot checks.

Fixes https://github.com/humanmade/product-dev/issues/1582