### PR TITLE
Disable loading column values in audit log by default

### DIFF
--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -203,6 +203,15 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 	 * @return array
 	 */
 	public function get_column_values( $column ) {
+
+		// By default we don't load the column values, as doing so is very slow and pages
+		// will likely timeout. The column values will still function, it's just that options
+		// in drop-downs will show _all_ values, not just the ones that exist in the db of
+		// audit logs.
+		if ( ! apply_filters( 'altis.cloud.audit_log_load_column_values', false ) ) {
+			return [];
+		}
+
 		$values = wp_cache_get( $column, 'stream_column_values' );
 		if ( $values === false ) {
 			$query = "stats distinct( $column ) by $column";


### PR DESCRIPTION
Calculating the column values is very slow and mostly leads to timeouts on loading the page. Having the column values just improves the UI slightly by greying out values that are not in the DB. It doesn't stop the `<select>` from showing all filter options.

I added this as a filter incase anyone would still want this functionality.
