### PR TITLE
Flush Cavalcade Logs every job

### DIFF
--- a/inc/cavalcade_runner_to_cloudwatch/namespace.php
+++ b/inc/cavalcade_runner_to_cloudwatch/namespace.php
@@ -188,7 +188,7 @@ function on_end_job( Worker $worker, Job $job, string $status ) {
 	$error_output_property->setAccessible( true );
 	$error_output = $error_output_property->getValue( $worker );
 
-	Cloud\get_logger( 'cavalcade', $status )->info( json_encode( [
+	Cloud\get_logger( 'cavalcade', $status, 1 )->info( json_encode( [
 		'hook'     => $job->hook,
 		'id'       => $job->id,
 		'site_url' => $job->get_site_url(),

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1079,9 +1079,12 @@ function is_cloud() : bool {
  *                          will not be created if it does not already exist.
  * @param string $log_stream Name of the log stream. This value is used as
  *                           provided.
+ * @param int $batch_size The amount of log items to buffer before flushing them.
+ *                        FLogs are automatically flushed / written out when the
+ *                        LoggerInterface is destructed. Defaults to 1000.
  * @return Psr\Log\LoggerInterface
  */
-function get_logger( string $log_group, string $log_stream ) : LoggerInterface {
+function get_logger( string $log_group, string $log_stream, int $batch_size = 1000 ) : LoggerInterface {
 	// $tag_name is designed to be used with Fluent Bit and doubles as a nice
 	// index for storing our loggers in. Tags must be prefixed with 'app.' to be
 	// correctly routed by our Fluent Bit container. Fluent Bit is configured
@@ -1119,7 +1122,7 @@ function get_logger( string $log_group, string $log_stream ) : LoggerInterface {
 			Altis\get_environment_name() . '/' . $log_group,
 			$log_stream,
 			null, // log retention when creating a new group (we disable this).
-			1000, // how many logs to send in a single batch.
+			$batch_size, // how many logs to send in a single batch.
 			[],  // tags for log group (we disable group creation).
 			Logger::DEBUG, // PSR log level.
 			true, // bubble logs through multiple handlers.


### PR DESCRIPTION
Currently we're buffering up to 1,000 log entries (with a max of 24 hours) for cavalcade logs which makes a significant delay in them appearing in the Altis Dashboard.

This doesn't change the cost of PutLogEvents which is based off event count, regardless of whether they are in separate API calls or not.

Fixes https://github.com/humanmade/product-dev/issues/1664
