### PR TITLE
Switch to upstream wp-redis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"humanmade/aws-xray": "~1.3.7",
 		"humanmade/s3-uploads": "^3.0.7",
 		"humanmade/cavalcade": "^2.0.2",
-		"humanmade/wp-redis": "1.4.4",
+		"pantheon-systems/wp-redis": "1.4.4",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",
 		"humanmade/batcache": "~1.5.2",
 		"humanmade/ludicrousdb": "~5.0.6",
@@ -47,7 +47,7 @@
 				"humanmade/aws-xray",
 				"humanmade/s3-uploads",
 				"humanmade/cavalcade",
-				"humanmade/wp-redis",
+				"pantheon-systems/wp-redis",
 				"humanmade/ludicrousdb",
 				"humanmade/aws-ses-wp-mail"
 			]

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -426,7 +426,7 @@ function load_object_cache_redis() {
 	Alloptions_Fix\bootstrap();
 	\WP_Predis\add_filters();
 
-	require Altis\ROOT_DIR . '/vendor/humanmade/wp-redis/object-cache.php';
+	require Altis\ROOT_DIR . '/vendor/pantheon-systems/wp-redis/object-cache.php';
 
 	// cache must be initted once it's included, else we'll get a fatal.
 	wp_cache_init();
@@ -602,7 +602,7 @@ function load_plugins() {
 	}
 
 	if ( $config['redis'] ) {
-		require_once Altis\ROOT_DIR . '/vendor/humanmade/wp-redis/wp-redis.php';
+		require_once Altis\ROOT_DIR . '/vendor/pantheon-systems/wp-redis/wp-redis.php';
 	}
 
 	if ( $config['aws-ses-wp-mail'] ) {


### PR DESCRIPTION
Now that the Pantheon Systems original `wp-redis` is available from [packagist.org](https://packagist.org/packages/pantheon-systems/wp-redis), we can switch to using it.

Fixes https://github.com/humanmade/altis-cloud/issues/866
