### PR TITLE
Update Predis adaptor to 0.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"require": {
 		"php": ">=7.1",
-		"humanmade/wp-redis-predis-client": "0.1.1",
+		"humanmade/wp-redis-predis-client": "0.1.2",
 		"humanmade/aws-xray": "~1.3.7",
 		"humanmade/s3-uploads": "^3.0.7",
 		"humanmade/cavalcade": "^2.0.2",


### PR DESCRIPTION
Includes https://github.com/humanmade/wp-redis-predis-client/pull/14 which will show when cache flushes happen