### PR TITLE
Update dependabot for v22 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
+  target-branch: v22-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
   target-branch: v21-branch
 - package-ecosystem: composer
   directory: "/"
@@ -35,12 +44,3 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v19-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v18-branch


### PR DESCRIPTION
- Update dependabot for v22 release.
- Remove v17 release.

- Delivers https://github.com/humanmade/product-dev/issues/1696