### PR TITLE
Remove warning when elasticsearch is turned off

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -138,8 +138,10 @@ function bootstrap() {
 	Environment_Indicator\bootstrap();
 
 	// Sign Elasticsearch HTTP requests and log errors.
-	add_action( 'http_api_debug', __NAMESPACE__ . '\\log_elasticsearch_request_errors', 10, 5 );
-	add_filter( 'http_request_args', __NAMESPACE__ . '\\on_http_request_args', 11, 2 );
+	if ( isset( $config['elasticsearch'] ) && $config['elasticsearch'] ) {
+		add_action( 'http_api_debug', __NAMESPACE__ . '\\log_elasticsearch_request_errors', 10, 5 );
+		add_filter( 'http_request_args', __NAMESPACE__ . '\\on_http_request_args', 11, 2 );
+	}
 
 	// Disallow file mods.
 	if ( is_cloud() ) {


### PR DESCRIPTION
When turning off elasticsearch for local server, ensure we don't try to reference the host.

Addresses https://github.com/humanmade/altis-local-server/issues/257