### PR TITLE
Update the minimum PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		]
 	},
 	"require": {
-		"php": ">=7.1",
+		"php": ">=8.2",
 		"humanmade/wp-redis-predis-client": "0.1.2",
 		"humanmade/aws-xray": "~1.3.7",
 		"humanmade/s3-uploads": "^3.0.7",


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: humanmade/product-dev#1735