### PR TITLE
Fix link to DNS Configuration docs

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -3,7 +3,7 @@
 Altis automatically provisions, maintains, and renews TLS certificates for your domains. TLS configuration is managed by Altis,
 including the use of secure algorithms.
 
-Domains are validated for SSL provisioning as part of the [DNS configuration process](../dns-configuration.md) when adding a new
+Domains are validated for SSL provisioning as part of the [DNS configuration process](./dns-configuration.md) when adding a new
 domain.
 
 Certificates issued by Altis use RSA 2048-bit keys, signed by the Amazon certificate authority.


### PR DESCRIPTION
The link to DNS Configuration on https://docs.altis-dxp.com/cloud/https/ is broken as it is missing the `/cloud` portion of the URL. Comparing to other pages at the same level (eg. https://docs.altis-dxp.com/cloud/afterburner/), looks like the link should just have one `.`. 