### PR TITLE
Order PHP information from newest to oldest.

### DIFF
--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -7,7 +7,7 @@ order: 100
 
 The following versions are available, and the specific version in use will depend on your configuration.
 
-- PHP Version: 8.0, 8.1, 8.2, 8.3  see [Altis compatibility chart](docs://guides/updating-php/#altis-compatibility-chart)
+- PHP Version: 8.3, 8.2, 8.1, 8.0  see [Altis compatibility chart](docs://guides/updating-php/#altis-compatibility-chart)
 - MySQL Version: 8.0 (compatible; using AWS Aurora)
 
 ## PHP Modules


### PR DESCRIPTION
Bugbear of mine. This sort of information reads better when displayed newest to oldest.