### PR TITLE
Add link to local server instructions

### DIFF
--- a/docs/afterburner.md
+++ b/docs/afterburner.md
@@ -21,3 +21,11 @@ Should the Redis server disconnect or be unavailable for a period, the local cac
 ## Activation
 
 To activate Afterburner on your environment, [create a support ticket](support://new) with the request.
+
+To activate Afterburner on your local development environment, see
+[this page for instructions](docs://local-server/using-afterburner.md).
+
+## Statistics
+
+Once Afterburner is enabled on your environment, an Afterburner item is added to the Query Monitor Toolbar Menu. This item
+provides some statistics about the Afterburner cache, including the number of hits and misses, and the total memory used.


### PR DESCRIPTION
This change adds a link to the local server page showing how to enable Afterburner.

It also mentions the Afterburner addition to Query Monitor.

<img width="1251" height="684" alt="CleanShot 2025-07-21 at 18 11 44" src="https://github.com/user-attachments/assets/4b6e2b36-8309-4e98-a287-02d92eb80928" />


Hat tip to @svandragt via PR https://github.com/humanmade/altis-cloud/pull/981