### PR TITLE
Fix metadata to check for IMDSV2

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -877,7 +877,7 @@ function get_ec2_instance_metadata() : array {
 		if ( $token_response->getStatusCode() === 200 ) {
 			$token = (string) $token_response->getBody();
 		} else {
-			trigger_error('IMDSv2 token request failed', E_USER_NOTICE);
+			trigger_error( 'IMDSv2 token request failed', E_USER_NOTICE );
 			if ( function_exists( 'apcu_store' ) ) {
 				apcu_store( $cache_key, [] );
 			}


### PR DESCRIPTION
### Changelog

- Adds IMDSv2 token fetching
- Removes IMDSv1 

### How to test

- Considering your Altis project runs in a IMDSv2-enabled instance.
- Add to your project, in `composer.json` `require` section the line:

```
"altis/cloud": "dev-fix-metadata as 23.0.1",
```
- Add to the `repositories` section:
```
{
        "type": "vcs",
        "url": "git@github.com:humanmade/altis-cloud.git"
}
``` 
- Push and build a new image
- Login into your image (or Altis CLI) and run:
```
wp shell
> Altis\Cloud\get_ec2_instance_metadata()
[
    "accountId" => "xxxxxxx",
    "architecture" => "x86_64",
    "availabilityZone" => "eu-xx-1c",
    "billingProducts" => null,
    "devpayProductCodes" => null,
    "marketplaceProductCodes" => null,
    "imageId" => "ami-xxxxx",
    "instanceId" => "i-xxxxx",
    "instanceType" => "t3.small",
    "kernelId" => null,
    "pendingTime" => "2025-08-06T18:08:15Z",
    "privateIp" => "172.xx.xx.xx",
    "ramdiskId" => null,
    "region" => "eu-xx-1",
    "version" => "2017-09-30",
  ]
``` 
- If you see a similar output this means the `token` has been successfully retrieved. An error indicates a problem and should be reported in this PR.
