### PR TITLE
Update wp-redis-predis-client to 0.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"require": {
 		"php": ">=8.2",
-		"humanmade/wp-redis-predis-client": "0.1.2",
+		"humanmade/wp-redis-predis-client": "~0.2.0",
 		"humanmade/aws-xray": "~1.3.8",
 		"humanmade/s3-uploads": "^3.0.10",
 		"humanmade/cavalcade": "^2.0.2",


### PR DESCRIPTION
Updates to pull in `wp-redis-predis-client` to 0.2.x

- Addresses https://github.com/humanmade/product-dev/issues/1836
