### PR TITLE
Catch up with v25-branch where this already got updated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"humanmade/batcache": "~1.5.2",
 		"humanmade/ludicrousdb": "~5.0.7",
 		"humanmade/aws-ses-wp-mail": "~1.3.1",
-		"monolog/monolog": "^2.9",
+		"monolog/monolog": "^3.9",
 		"maxbanton/cwh": "^2.0"
 	},
 	"extra": {


### PR DESCRIPTION
This major version was blocked in a previous Dependabot PR. But it should not have been. We already updated in v25 so it's safe to do so here.