### PR TITLE
Update WAF documentation with expanded security details

### DIFF
--- a/docs/WAF/README.md
+++ b/docs/WAF/README.md
@@ -66,11 +66,8 @@ You can now self-manage allow lists to allow specific IP addresses through the f
 
 Altis maintains a global team of cloud engineers on-call with multiple tiers of coverage, 24/7/365.
 
-We use a wide range of alerts covering both internal and external metrics:
-
-- **Internal metrics**: CPU usage, memory usage, disk space, scaling behaviour, and network throughput.
-- **External metrics**: Error rates experienced by customers, including server error thresholds that trigger alerts when a
-  significant proportion of requests are failing.
+We monitor system performance and customer impact metrics around the clock. Our on-call engineers are notified of issues via
+alerts with automatic escalation if needed.
 
 Additionally, urgent support tickets filed via the Altis Dashboard or the emergency email address trigger an alert to on-call
 engineers immediately.

--- a/docs/WAF/README.md
+++ b/docs/WAF/README.md
@@ -13,16 +13,34 @@ The Altis WAF includes protection against web exploits, including Cross-Site Scr
 inputs. It also includes protection against access to private files accidentally published in your codebase, including .sql and .sh
 files.
 
-The Altis team manages these protections automatically across the platform on your behalf.
+Our WAF blocks known-bad actors based on IP address and behaviour, using public reputation lists including AWS' IP reputation list and
+managed rules for known attack patterns. We also block access to certain sensitive files and system paths, and at an application level
+(as set in your configuration) access to the XML-RPC API.
+
+The Altis team proactively manages these protections on your behalf, including updating rules in response to newly discovered
+vulnerabilities in WordPress and commonly used plugins.
 
 ## Protection against request floods & denial of service attacks
 
-The Altis WAF provides protection against denial of service (DoS) and distributed denial of service (DDoS) attacks.
+The Altis WAF provides protection against denial of service (DoS) and distributed denial of service (DDoS) attacks through a
+multi-layered approach built on AWS WAF and AWS Shield Advanced.
 
-Per-IP rate limits are applied across all environments as standard, both across the entire environment as well as per-container, to
-ensure individual bad actors are limited from being able to adversely affect your site. Rate limits are monitored and adjusted
-across the platform depending on industry-wide threat analysis; contact Altis support for further information about the
-currently-applied rate limits.
+DDoS protection operates at multiple network layers:
+
+- **Layers 3 & 4** (network and transport): Managed automatically through AWS WAF, providing protection against volumetric and
+  protocol-based attacks.
+- **Layer 7** (application): Managed through WAF rules, and where necessary, through collaboration with the AWS Shield Response
+  Team (SRT).
+
+Per-IP rate limits are applied at multiple tiers across all environments as standard:
+
+- **CDN-level rate limits** apply across the entire environment, tuned by our engineers based on your traffic patterns. Contact Altis
+  support if you need these adjusted.
+- **Per-container rate limits** restrict the rate of requests to dynamic pages (PHP) on each application server.
+- **Sensitive page rate limits** apply stricter controls to login and administration pages.
+
+These rate limits are monitored and adjusted across the platform depending on industry-wide threat analysis; contact Altis support
+for further information about the currently-applied rate limits.
 
 Altis also includes advanced DDoS protection as standard for our customers. We actively monitor all environments for attacks, with
 automated interventions and mitigation. Our engineers are on-call 24/7 to respond if necessary, and we work with the AWS Shield
@@ -42,8 +60,34 @@ For customers with additional DDoS mitigation in place, legitimate backend users
 at a higher rate than normal. As part of organizing additional mitigation, Altis engineers can relax these mitigation for your
 users. (Note that regular firewall rules may still apply.)
 
-Advanced bypassing of our firewall, such as allowing specific IP addresses through ("whitelisting"), requires firewall
-customisation.
+You can now self-manage allow lists to allow specific IP addresses through the firewall.
+
+## Monitoring & alerting
+
+Altis maintains a global team of cloud engineers on-call with multiple tiers of coverage, 24/7/365.
+
+We use a wide range of alerts covering both internal and external metrics:
+
+- **Internal metrics**: CPU usage, memory usage, disk space, scaling behaviour, and network throughput.
+- **External metrics**: Error rates experienced by customers, including server error thresholds that trigger alerts when a
+  significant proportion of requests are failing.
+
+Additionally, urgent support tickets filed via the Altis Dashboard or the emergency email address trigger an alert to on-call
+engineers immediately.
+
+## Incident response
+
+When alerts are triggered, our engineers are notified through a tiered escalation system. If the primary on-call engineer does not
+acknowledge the alert promptly, it is automatically escalated through secondary and tertiary on-call engineers, and ultimately to
+engineering leadership.
+
+Once an alert is validated, engineers begin our incident management process:
+
+1. An incident is created and categorised.
+2. Your listed contact emails are notified immediately when an incident is created.
+3. Engineers provide regular updates throughout the incident.
+4. After resolution, an incident report is provided.
+5. Where necessary, a root cause analysis is undertaken and shared.
 
 ## Firewall customizations
 

--- a/docs/WAF/README.md
+++ b/docs/WAF/README.md
@@ -15,7 +15,7 @@ files.
 
 Our WAF blocks known-bad actors based on IP address and behaviour, using public reputation lists including AWS' IP reputation list and
 managed rules for known attack patterns. We also block access to certain sensitive files and system paths, and at an application level
-(as set in your configuration) access to the XML-RPC API.
+[access to the XML-RPC API (as set in your configuration)](docs://cms/xmlrpc/).
 
 The Altis team proactively manages these protections on your behalf, including updating rules in response to newly discovered
 vulnerabilities in WordPress and commonly used plugins.
@@ -36,7 +36,7 @@ Per-IP rate limits are applied at multiple tiers across all environments as stan
 
 - **CDN-level rate limits** apply across the entire environment, tuned by our engineers based on your traffic patterns. Contact Altis
   support if you need these adjusted.
-- **Per-container rate limits** restrict the rate of requests to dynamic pages (PHP) on each application server.
+- **Per-container rate limits** restrict the rate of requests to dynamic pages (PHP) on each application container.
 - **Sensitive page rate limits** apply stricter controls to login and administration pages.
 
 These rate limits are monitored and adjusted across the platform depending on industry-wide threat analysis; contact Altis support


### PR DESCRIPTION
## Updated the following sections:

Protection against exploits — expanded to mention:

- IP reputation lists (including AWS') and managed rules for known attack patterns
- Blocking of sensitive files, system paths, and XML-RPC API
- Proactive rule updates for newly discovered vulnerabilities (without mentioning the advance notice agreement)

Protection against request floods — expanded with:

- Layers 3, 4, and 7 breakdown (network, transport, application)
- Three tiers of rate limits described generically: CDN-level, per-container (dynamic pages), and sensitive pages (login/admin) — no exact numbers
- I also mentioned the self-service allow-lists (but couldn't find a page to point to)

New "Monitoring & alerting" section — covers:

- 24/7/365 global on-call team with multiple tiers
- Internal metrics (CPU, memory, disk, scaling, network) and external metrics (error rates)
- Urgent support ticket alerting

New "Incident response" section — covers:

- Tiered escalation (primary → secondary → tertiary → leadership) without exact timeframes
- Five-step incident process: creation, customer notification, updates, report, root cause analysis

I specifically didn't mention:

- Exact rate limit numbers
- Specific error rate thresholds
- Exact escalation timeframes
- Details about advance WordPress vulnerability notice agreements
- Internal tooling names like PagerDuty

- Fixes:  https://github.com/humanmade/altis-documentation/issues/602
