### PR TITLE
Update afterburner-object-cache to 1.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 		"humanmade/aws-ses-wp-mail": "~1.3.1",
 		"monolog/monolog": "^2.11",
 		"maxbanton/cwh": "^2.0",
-		"humanmade/afterburner-object-cache": "^1.0.4"
+		"humanmade/afterburner-object-cache": "^1.0.5"
 	},
 	"extra": {
 		"altis": {


### PR DESCRIPTION
- Updates afterburner-object-cache to 1.0.5 - https://github.com/humanmade/afterburner-object-cache/releases/tag/1.0.5