### PR TITLE
Add PHP 8.5 to cloud specifications

### DIFF
--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -7,7 +7,7 @@ order: 100
 
 The following versions are available, and the specific version in use will depend on your configuration.
 
-- PHP Version: 8.4, 8.3, 8.2, 8.1  see [Altis compatibility chart](docs://guides/updating-php/#altis-compatibility-chart)
+- PHP Version: 8.5, 8.4, 8.3, 8.2, 8.1  see [Altis compatibility chart](docs://guides/updating-php/#altis-compatibility-chart)
 - MySQL Version: 8.0 (compatible; using AWS Aurora)
 
 ## PHP Modules


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the list of available PHP versions in `docs/specifications.md`.

This is part of the documentation update work for PHP 8.5 support (see humanmade/product-dev#2012, "All Altis documentation references are updated to reflect PHP8.5 compatibility and usage").

Other PHP-version-aware docs (compatibility chart in `altis/documentation`, skeleton `composer.json`, local-server `php-version.md`, dev-tools workflow defaults) deliberately track the *default* PHP version and do not need updating yet.

Refs humanmade/product-dev#2012

## Test plan
- [ ] Verify the rendered docs page lists `8.5, 8.4, 8.3, 8.2, 8.1` under "PHP Version" and the compatibility chart link still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)