### PR TITLE
Update GHA reusable workflow ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@master
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@088bce7321fde60b9c22e792e764fa13ccd8f6ab
     with:
       altis-package: altis/cloud
     secrets:


### PR DESCRIPTION
Pin to altis-dev-tools tip past #1056 (artifact name + module-config input + Packagist bypass + other follow-ups).