### PR TITLE
Document PHP-FPM max_children warning

### DIFF
--- a/docs/dashboard/logs.md
+++ b/docs/dashboard/logs.md
@@ -16,6 +16,19 @@ The date range can be specified for all logs types. Some log types will also sup
 
 ![Screenshot of a logs filter being applied](../assets/logs-with-filter.png)
 
+## Common PHP-FPM warnings
+
+You may occasionally see PHP-FPM warnings similar to the following in the PHP error logs:
+
+```text
+server reached pm.max_children setting, consider raising it
+```
+
+This warning is expected on Altis Cloud and does not indicate that your application needs a PHP-FPM configuration change.
+Altis Cloud manages request capacity by automatically scaling web containers horizontally, rather than by increasing the number of
+PHP-FPM workers within a single container. In most cases, this log entry can be ignored unless it correlates with user-visible
+performance issues or other application errors.
+
 ## Log Delivery
 
 Log delivery to CloudWatch can be switched off, however this is not recommended as logs will not be available in the Altis


### PR DESCRIPTION
## Describe the PR 

Adds a note to the dashboard logs documentation for the common PHP-FPM warning:

```text
server reached pm.max_children setting, consider raising it
```

The note clarifies that this warning is expected on Altis Cloud and is generally not relevant/actionable because request capacity is handled through horizontal autoscaling of web containers rather than increasing PHP-FPM workers within a single container.

Related support context: Zendesk #11334.

---

## For Altis Team Use

### Completion Checklist
Does this PR meet our definition of done? See [the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [ ] Has the acceptance criteria been met?
- [x] Is the documentation updated (including README)?
- [x] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
    - [x] OR, are manual tests documented (at least on the ticket/PR)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [ ] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan, if required?
