### PR TITLE
Pin reusable CI workflow to module-ci-v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@088bce7321fde60b9c22e792e764fa13ccd8f6ab
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@module-ci-v1
     with:
       altis-package: altis/cloud
     secrets:


### PR DESCRIPTION
Switches this module's CI caller from the frozen `module-ci.yml@<sha>` pin to the
`@module-ci-v1` moving tag on `humanmade/altis-dev-tools`.

The reusable workflow now detects the runner PHP from `config.platform.php`
(humanmade/altis-dev-tools#1079), so one tag serves every branch at the PHP it
declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)