### PR TITLE
Pin s3 uploads version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"php": ">=8.2",
 		"humanmade/wp-redis-predis-client": "~0.2.0",
 		"humanmade/aws-xray": "~1.3.11",
-		"humanmade/s3-uploads": "^3.0.13",
+		"humanmade/s3-uploads": "^3.0.12",
 		"humanmade/cavalcade": "^2.0.3",
 		"pantheon-systems/wp-redis": "1.4.7",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"php": ">=8.2",
 		"humanmade/wp-redis-predis-client": "~0.2.0",
 		"humanmade/aws-xray": "~1.3.11",
-		"humanmade/s3-uploads": "^3.0.12",
+		"humanmade/s3-uploads": "=3.0.12",
 		"humanmade/cavalcade": "^2.0.3",
 		"pantheon-systems/wp-redis": "1.4.7",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"php": ">=8.2",
 		"humanmade/wp-redis-predis-client": "~0.2.0",
 		"humanmade/aws-xray": "~1.3.11",
-		"humanmade/s3-uploads": "=3.0.12",
+		"humanmade/s3-uploads": "3.0.12",
 		"humanmade/cavalcade": "^2.0.3",
 		"pantheon-systems/wp-redis": "1.4.7",
 		"humanmade/wordpress-pecl-memcached-object-cache": "2.1.0",


### PR DESCRIPTION
This change pins `humanmade/s3-uploads` to version 3.0.12.
Allowing composer to pull in a higher version (which `s3-uploads` 3.0.13 does) is incompatible with the `aws-sdk-php` version pinned in `altis/core`. Which, in turn, would break Local Server uploads if allowed to increase.

Addresses issue https://github.com/humanmade/product-dev/pull/2187
